### PR TITLE
feature: export e2e tests with static site

### DIFF
--- a/packages/build/src/build-static.js
+++ b/packages/build/src/build-static.js
@@ -13,6 +13,7 @@ await cp(path.join(root, 'dist'), path.join(root, 'dist2'), {
 
 const { commitHash } = await exportStatic({
   extensionPath: 'packages/extension',
+  testPath: 'packages/e2e',
   root,
 })
 


### PR DESCRIPTION
Export the media-preview e2e suite as part of the static site so the deployed /tests page lists and launches the available tests.