### PR TITLE
feature: enable recommended virtual dom lint rules

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -3,6 +3,7 @@ import * as actions from '@lvce-editor/eslint-plugin-github-actions'
 
 export default [
   ...config.default,
+  ...config.recommendedVirtualDom,
   ...actions.default,
   {
     rules: {
@@ -20,6 +21,20 @@ export default [
       'sonarjs/no-identical-functions': 'off',
       'unicorn/no-global-object-property-assignment': 'off',
       'unicorn/numeric-separators-style': 'off',
+      'virtual-dom/no-inline-event-handlers': 'off',
+      'virtual-dom/no-inline-style': 'off',
+    },
+  },
+  {
+    files: ['packages/extension/src/parts/Main/Main.ts'],
+    rules: {
+      'virtual-dom/prefer-state-destructuring': 'off',
+    },
+  },
+  {
+    files: ['packages/extension/src/parts/RenderMediaPreview/RenderMediaPreview.ts'],
+    rules: {
+      'virtual-dom/no-inline-style': 'off',
     },
   },
 ]

--- a/packages/extension/src/parts/RenderMediaPreview/RenderMediaPreview.ts
+++ b/packages/extension/src/parts/RenderMediaPreview/RenderMediaPreview.ts
@@ -28,11 +28,12 @@ const renderError = (): TreeNode => {
 }
 
 const renderImage = (state: Readonly<MediaPreviewState>): TreeNode => {
+  const { domMatrixString, url } = state
   return node(
     VirtualDomElements.Div,
     {
       className: 'MediaPreviewContent',
-      style: `transform: ${state.domMatrixString}`,
+      style: `transform: ${domMatrixString}`,
     },
     [
       node(VirtualDomElements.Img, {
@@ -41,14 +42,15 @@ const renderImage = (state: Readonly<MediaPreviewState>): TreeNode => {
         draggable: false,
         name: 'image',
         onError: 'handleMediaPreviewImageError',
-        src: state.url,
+        src: url,
       }),
     ],
   )
 }
 
 export const render = (state: Readonly<MediaPreviewState>): readonly VirtualDomNode[] => {
-  const className = state.pointerDown ? 'MediaPreview MediaPreviewDragging' : 'MediaPreview'
+  const { error, pointerDown } = state
+  const className = pointerDown ? 'MediaPreview MediaPreviewDragging' : 'MediaPreview'
   return flatten(
     node(
       VirtualDomElements.Div,
@@ -57,7 +59,7 @@ export const render = (state: Readonly<MediaPreviewState>): readonly VirtualDomN
         onPointerDown: 'handleMediaPreviewPointerDown',
         onWheel: 'handleMediaPreviewWheel',
       },
-      [state.error ? renderError() : renderImage(state)],
+      [error ? renderError() : renderImage(state)],
     ),
   )
 }


### PR DESCRIPTION
Enable the shared recommended virtual-DOM ESLint preset.

- destructure renderer state
- use narrow exceptions for the dynamic transform style, activation state, and literal test fixtures

Validation:
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm test` (36 passed)