### PR TITLE
fix: wrap media preview image

### DIFF
--- a/packages/extension/media/index.css
+++ b/packages/extension/media/index.css
@@ -25,6 +25,10 @@
   -webkit-user-drag: none;
 }
 
+.MediaPreviewImageWrapper {
+  contain: content;
+}
+
 .MediaPreviewDragging {
   cursor: grabbing;
 }

--- a/packages/extension/src/parts/RenderMediaPreview/RenderMediaPreview.ts
+++ b/packages/extension/src/parts/RenderMediaPreview/RenderMediaPreview.ts
@@ -36,14 +36,16 @@ const renderImage = (state: Readonly<MediaPreviewState>): TreeNode => {
       style: `transform: ${domMatrixString}`,
     },
     [
-      node(VirtualDomElements.Img, {
-        alt: '',
-        className: 'MediaPreviewImage',
-        draggable: false,
-        name: 'image',
-        onError: 'handleMediaPreviewImageError',
-        src: url,
-      }),
+      node(VirtualDomElements.Div, { className: 'MediaPreviewImageWrapper' }, [
+        node(VirtualDomElements.Img, {
+          alt: '',
+          className: 'MediaPreviewImage',
+          draggable: false,
+          name: 'image',
+          onError: 'handleMediaPreviewImageError',
+          src: url,
+        }),
+      ]),
     ],
   )
 }

--- a/packages/extension/test/RenderMediaPreview.test.ts
+++ b/packages/extension/test/RenderMediaPreview.test.ts
@@ -9,7 +9,7 @@ const state = {
   url: '/remote/image.png',
 }
 
-test('renders the image directly in the virtual dom', () => {
+test('renders the image inside a wrapper', () => {
   const dom = render(state)
 
   expect(dom).toEqual([
@@ -24,6 +24,11 @@ test('renders the image directly in the virtual dom', () => {
       childCount: 1,
       className: 'MediaPreviewContent',
       style: 'transform: matrix(1, 0, 0, 1, 10, 20)',
+      type: VirtualDomElements.Div,
+    },
+    {
+      childCount: 1,
+      className: 'MediaPreviewImageWrapper',
       type: VirtualDomElements.Div,
     },
     {


### PR DESCRIPTION
Wrap MediaPreviewImage in a dedicated MediaPreviewImageWrapper element and apply content containment to the wrapper. Update the render regression test for the new DOM structure.