### PR TITLE
fix: use dynamic css for media preview transform

### DIFF
--- a/packages/extension/media/index.css
+++ b/packages/extension/media/index.css
@@ -1,4 +1,5 @@
 .MediaPreview {
+  --MediaPreviewTransform: matrix(1, 0, 0, 1, 0, 0);
   width: 100%;
   height: 100%;
   contain: strict;
@@ -15,6 +16,7 @@
   display: flex;
   align-items: center;
   justify-content: center;
+  transform: var(--MediaPreviewTransform);
   transform-origin: center;
 }
 

--- a/packages/extension/src/parts/GetCss/GetCss.ts
+++ b/packages/extension/src/parts/GetCss/GetCss.ts
@@ -1,0 +1,5 @@
+export const getCss = (domMatrixString: string): string => {
+  return `.MediaPreview {
+  --MediaPreviewTransform: ${domMatrixString};
+}`
+}

--- a/packages/extension/src/parts/MediaPreviewViewInstance/MediaPreviewViewInstance.ts
+++ b/packages/extension/src/parts/MediaPreviewViewInstance/MediaPreviewViewInstance.ts
@@ -1,5 +1,6 @@
 import type { ViewContext, ViewEvent, VirtualDomViewInstance } from '@lvce-editor/api'
 import type { VirtualDomNode } from '@lvce-editor/virtual-dom-worker'
+import { getCss } from '../GetCss/GetCss.ts'
 import * as MediaPreview from '../MediaPreview/MediaPreview.ts'
 import { render } from '../RenderMediaPreview/RenderMediaPreview.ts'
 
@@ -15,6 +16,7 @@ interface MediaPreviewViewContext extends ViewContext {
 }
 
 export interface MediaPreviewViewInstance extends VirtualDomViewInstance {
+  readonly getCss: () => string
   readonly handleMediaPreviewImageError: () => void
   readonly handleMediaPreviewPointerDown: (x: unknown, y: unknown) => void
   readonly handleMediaPreviewPointerMove: (x: unknown, y: unknown) => void
@@ -77,6 +79,9 @@ export const createInstanceWithApi = async (
   return {
     dispose(): void {
       api.dispose(id)
+    },
+    getCss(): string {
+      return getCss(state.domMatrixString)
     },
     handleEvent(event: Readonly<ViewEvent>): void {
       if (event.type === 'error') {

--- a/packages/extension/src/parts/MediaPreviewViewInstance/MediaPreviewViewInstance.ts
+++ b/packages/extension/src/parts/MediaPreviewViewInstance/MediaPreviewViewInstance.ts
@@ -81,7 +81,8 @@ export const createInstanceWithApi = async (
       api.dispose(id)
     },
     getCss(): string {
-      return getCss(state.domMatrixString)
+      const { domMatrixString } = state
+      return getCss(domMatrixString)
     },
     handleEvent(event: Readonly<ViewEvent>): void {
       if (event.type === 'error') {

--- a/packages/extension/src/parts/RenderMediaPreview/RenderMediaPreview.ts
+++ b/packages/extension/src/parts/RenderMediaPreview/RenderMediaPreview.ts
@@ -28,12 +28,11 @@ const renderError = (): TreeNode => {
 }
 
 const renderImage = (state: Readonly<MediaPreviewState>): TreeNode => {
-  const { domMatrixString, url } = state
+  const { url } = state
   return node(
     VirtualDomElements.Div,
     {
       className: 'MediaPreviewContent',
-      style: `transform: ${domMatrixString}`,
     },
     [
       node(VirtualDomElements.Div, { className: 'MediaPreviewImageWrapper' }, [

--- a/packages/extension/test/GetCss.test.ts
+++ b/packages/extension/test/GetCss.test.ts
@@ -1,0 +1,8 @@
+import { expect, test } from '@jest/globals'
+import { getCss } from '../src/parts/GetCss/GetCss.ts'
+
+test('returns the media preview transform as dynamic css', () => {
+  expect(getCss('matrix(1, 0, 0, 1, 10, 20)')).toBe(`.MediaPreview {
+  --MediaPreviewTransform: matrix(1, 0, 0, 1, 10, 20);
+}`)
+})

--- a/packages/extension/test/MediaPreviewViewInstance.test.ts
+++ b/packages/extension/test/MediaPreviewViewInstance.test.ts
@@ -40,6 +40,9 @@ test('creates a preview and renders its image', async () => {
   expect(api.getState).toHaveBeenCalledWith(7)
   expect(api.getUrl).toHaveBeenCalledWith('/workspace/image.png')
   expect(instance.render().some((node) => node.src === 'blob:https://example.com/image-id')).toBe(true)
+  expect(instance.getCss()).toBe(`.MediaPreview {
+  --MediaPreviewTransform: matrix(1, 0, 0, 1, 0, 0);
+}`)
 })
 
 test('renders an error when the image URL cannot be read', async () => {
@@ -71,6 +74,23 @@ test('forwards pointer and image events to the media preview api', async () => {
   instance.handleMediaPreviewImageError()
   expect(api.handleError).toHaveBeenCalledWith(7)
   expect(instance.render().some((node) => node.text === 'Image could not be loaded')).toBe(true)
+})
+
+test('updates the transform css without changing the virtual dom', async () => {
+  const api = createApi()
+  api.handleWheel.mockReturnValue({
+    ...initialState,
+    domMatrixString: 'matrix(2, 0, 0, 2, 10, 20)',
+  })
+  const instance = await createInstanceWithApi(context, api)
+  const oldDom = instance.render()
+
+  instance.handleMediaPreviewWheel(70, 0)
+
+  expect(instance.render()).toEqual(oldDom)
+  expect(instance.getCss()).toBe(`.MediaPreview {
+  --MediaPreviewTransform: matrix(2, 0, 0, 2, 10, 20);
+}`)
 })
 
 test('saves the URI with preview state and disposes the preview instance', async () => {

--- a/packages/extension/test/RenderMediaPreview.test.ts
+++ b/packages/extension/test/RenderMediaPreview.test.ts
@@ -23,7 +23,6 @@ test('renders the image inside a wrapper', () => {
     {
       childCount: 1,
       className: 'MediaPreviewContent',
-      style: 'transform: matrix(1, 0, 0, 1, 10, 20)',
       type: VirtualDomElements.Div,
     },
     {


### PR DESCRIPTION
Use a dynamic CSS variable for the media preview transform so pan and zoom updates do not change the virtual DOM or emit inline styles.