### PR TITLE
feature: disable production source maps

### DIFF
--- a/packages/build/src/build.js
+++ b/packages/build/src/build.js
@@ -27,7 +27,7 @@ fs.cpSync(join(extension, 'media'), join(root, 'dist', 'media'), {
 })
 
 const extensionBundlePath = join(root, 'dist', 'dist', 'mediaPreviewMain.js')
-await bundleJs(join(extension, 'src', 'mediaPreviewMain.ts'), extensionBundlePath)
+await bundleJs(join(extension, 'src', 'mediaPreviewMain.ts'), extensionBundlePath, false)
 
 await packageExtension({
   highestCompression: true,


### PR DESCRIPTION
Use the Rollup-based production bundler without emitting source maps for the media preview extension.