### PR TITLE
feature: enforce 95% branch coverage

### DIFF
--- a/packages/extension/package.json
+++ b/packages/extension/package.json
@@ -23,6 +23,12 @@
           "useESM": true
         }
       ]
+    },
+    "collectCoverage": true,
+    "coverageThreshold": {
+      "global": {
+        "branches": 95
+      }
     }
   },
   "devDependencies": {

--- a/packages/extension/test/HandleWheel.test.ts
+++ b/packages/extension/test/HandleWheel.test.ts
@@ -1,0 +1,63 @@
+import { beforeAll, expect, test } from '@jest/globals'
+import * as HandleWheel from '../src/parts/HandleWheel/HandleWheel.ts'
+import * as WebViewStates from '../src/parts/WebViewStates/WebViewStates.ts'
+
+beforeAll(() => {
+  // @ts-ignore
+  globalThis.DOMMatrix = class {
+    a = 1
+    b = 0
+    c = 0
+    d = 1
+    e = 0
+    f = 0
+
+    multiplySelf(domMatrix: DOMMatrixReadOnly) {
+      this.a *= domMatrix.a
+      this.d *= domMatrix.d
+      return this
+    }
+
+    scaleSelf(scale: number) {
+      this.a *= scale
+      this.d *= scale
+      return this
+    }
+
+    translateSelf(x: number, y: number) {
+      this.e += x
+      this.f += y
+      return this
+    }
+  }
+})
+
+const createState = () => ({
+  domMatrix: { a: 1, b: 0, c: 0, d: 1, e: 0, f: 0 } as DOMMatrixReadOnly,
+  error: false,
+  maxZoom: 2 ** 15,
+  minZoom: 0.1,
+  pointerDown: false,
+  pointerOffsetX: 0,
+  pointerOffsetY: 0,
+  zoomFactor: 200 as const,
+})
+
+test('ignores horizontal-only wheel events', () => {
+  const id = 101
+  const state = createState()
+  WebViewStates.set(id, state)
+
+  HandleWheel.handleWheel(id, 10, 20, 5, 0)
+
+  expect(WebViewStates.get(id)).toBe(state)
+})
+
+test('zooms into the pointer position for vertical wheel events', () => {
+  const id = 102
+  WebViewStates.set(id, createState())
+
+  HandleWheel.handleWheel(id, 10, 20, 0, -1)
+
+  expect(WebViewStates.get(id).domMatrix.a).toBeGreaterThan(1)
+})

--- a/packages/extension/test/IsFirefox.test.ts
+++ b/packages/extension/test/IsFirefox.test.ts
@@ -1,0 +1,42 @@
+import { afterEach, expect, jest, test } from '@jest/globals'
+
+const originalNavigator = Object.getOwnPropertyDescriptor(globalThis, 'navigator')
+
+const setNavigator = (navigator: unknown): void => {
+  Object.defineProperty(globalThis, 'navigator', {
+    configurable: true,
+    value: navigator,
+  })
+}
+
+const loadIsFirefox = async (): Promise<boolean> => {
+  jest.resetModules()
+  const module = await import('../src/parts/IsFirefox/IsFirefox.ts')
+  return module.isFirefox
+}
+
+afterEach(() => {
+  if (originalNavigator) {
+    Object.defineProperty(globalThis, 'navigator', originalNavigator)
+  } else {
+    delete (globalThis as { navigator?: unknown }).navigator
+  }
+})
+
+test('returns false when navigator is unavailable', async () => {
+  setNavigator(undefined)
+
+  await expect(loadIsFirefox()).resolves.toBe(false)
+})
+
+test('uses user agent brands when available', async () => {
+  setNavigator({ userAgentData: { brands: ['Firefox'] } })
+
+  await expect(loadIsFirefox()).resolves.toBe(true)
+})
+
+test('falls back to the user agent when brands are unavailable', async () => {
+  setNavigator({ userAgent: 'Mozilla Firefox', userAgentData: {} })
+
+  await expect(loadIsFirefox()).resolves.toBe(true)
+})

--- a/packages/extension/test/MediaPreviewViewInstance.test.ts
+++ b/packages/extension/test/MediaPreviewViewInstance.test.ts
@@ -51,6 +51,32 @@ test('renders an error when the image URL cannot be read', async () => {
   expect(instance.render().some((node) => node.text === 'Image could not be loaded')).toBe(true)
 })
 
+test('restores the URI from saved state when there is no current URI', async () => {
+  const api = createApi()
+  const savedContext = {
+    state: {
+      uri: '/workspace/saved-image.png',
+    },
+    uid: 8,
+    viewId: 'builtin.media-preview',
+  } as unknown as ViewContext
+
+  await createInstanceWithApi(savedContext, api)
+
+  expect(api.getUrl).toHaveBeenCalledWith('/workspace/saved-image.png')
+})
+
+test('uses defaults when the view context is missing', async () => {
+  const api = createApi()
+
+  const instance = await createInstanceWithApi(undefined, api)
+
+  expect(api.create).toHaveBeenCalledWith(0)
+  expect(api.setSavedState).toHaveBeenCalledWith(0, undefined)
+  expect(api.getUrl).not.toHaveBeenCalled()
+  expect(instance.render().some((node) => node.text === 'Image could not be loaded')).toBe(true)
+})
+
 test('forwards pointer and image events to the media preview api', async () => {
   const api = createApi()
   const instance = await createInstanceWithApi(context, api)
@@ -83,4 +109,26 @@ test('saves the URI with preview state and disposes the preview instance', async
   })
   await instance.dispose?.()
   expect(api.dispose).toHaveBeenCalledWith(7)
+})
+
+test('forwards legacy view events and normalizes invalid coordinates', async () => {
+  const api = createApi()
+  const instance = await createInstanceWithApi(context, api)
+
+  instance.handleEvent?.({ type: 'error' })
+  expect(api.handleError).toHaveBeenCalledWith(7)
+
+  instance.handleEvent?.({ name: 'pointerdown', type: 'contextmenu', x: Infinity, y: 20 })
+  expect(api.handlePointerDown).toHaveBeenCalledWith(7, 0, 20)
+
+  instance.handleEvent?.({ name: 'pointermove', type: 'contextmenu', x: 30, y: 40 })
+  expect(api.handlePointerMove).toHaveBeenCalledWith(7, 30, 40)
+
+  instance.handleEvent?.({ name: 'pointerup', type: 'contextmenu', x: 50, y: 60 })
+  expect(api.handlePointerUp).toHaveBeenCalledWith(7, 50, 60)
+
+  instance.handleEvent?.({ name: 'wheel', type: 'contextmenu', x: 70 })
+  expect(api.handleWheel).toHaveBeenCalledWith(7, 0, 0, 0, 70)
+
+  instance.handleEvent?.({ type: 'click' })
 })

--- a/packages/extension/test/SetSavedState.test.ts
+++ b/packages/extension/test/SetSavedState.test.ts
@@ -1,0 +1,57 @@
+import { beforeAll, expect, test } from '@jest/globals'
+import * as SetSavedState from '../src/parts/SetSavedState/SetSavedState.ts'
+import * as WebViewStates from '../src/parts/WebViewStates/WebViewStates.ts'
+
+beforeAll(() => {
+  // @ts-ignore
+  globalThis.DOMMatrixReadOnly = class {
+    a: number
+    b: number
+    c: number
+    d: number
+    e: number
+    f: number
+
+    constructor([a = 1, b = 0, c = 0, d = 1, e = 0, f = 0] = []) {
+      this.a = a
+      this.b = b
+      this.c = c
+      this.d = d
+      this.e = e
+      this.f = f
+    }
+  }
+})
+
+const createState = () => ({
+  domMatrix: {} as DOMMatrixReadOnly,
+  error: false,
+  maxZoom: 2 ** 15,
+  minZoom: 0.1,
+  pointerDown: false,
+  pointerOffsetX: 0,
+  pointerOffsetY: 0,
+  zoomFactor: 200 as const,
+})
+
+test.each([
+  ['missing state', undefined],
+  ['missing matrix', {}],
+  ['invalid matrix', { domMatrix: 1 }],
+])('uses the identity matrix for %s', (_name, savedState) => {
+  const id = 201
+  WebViewStates.set(id, createState())
+
+  SetSavedState.setSavedState(id, savedState)
+
+  expect(WebViewStates.get(id).domMatrix).toEqual({ a: 1, b: 0, c: 0, d: 1, e: 0, f: 0 })
+})
+
+test('restores a saved matrix', () => {
+  const id = 202
+  WebViewStates.set(id, createState())
+
+  SetSavedState.setSavedState(id, { domMatrix: 'matrix(1, 0, 0, 1, 10, 20)' })
+
+  expect(WebViewStates.get(id).domMatrix).toEqual({ a: 1, b: 0, c: 0, d: 1, e: 10, f: 20 })
+})


### PR DESCRIPTION
Enforces a 95% global Jest branch coverage threshold for the media-preview extension and adds focused tests for wheel handling, saved state, browser detection, and view-event routing.