### PR TITLE
fix: use flat virtual dom structure

### DIFF
--- a/packages/extension/src/parts/RenderMediaPreview/RenderMediaPreview.ts
+++ b/packages/extension/src/parts/RenderMediaPreview/RenderMediaPreview.ts
@@ -1,66 +1,59 @@
 import { text, VirtualDomElements, type VirtualDomNode } from '@lvce-editor/virtual-dom-worker'
 import type { MediaPreviewState } from '../MediaPreviewViewInstance/MediaPreviewViewInstance.ts'
 
-interface TreeNode {
-  readonly children: readonly TreeNode[]
-  readonly node: VirtualDomNode
-}
-
-const node = (type: number, properties: Readonly<Record<string, unknown>>, children: readonly TreeNode[] = []): TreeNode => {
-  return {
-    children,
-    node: {
-      ...properties,
-      childCount: children.length,
-      type,
-    },
-  }
-}
-
-const flatten = (tree: TreeNode): readonly VirtualDomNode[] => {
-  return [tree.node, ...tree.children.flatMap(flatten)]
-}
-
-const renderError = (): TreeNode => {
-  return node(VirtualDomElements.Div, { className: 'MediaPreviewError' }, [
-    node(VirtualDomElements.Span, {}, [{ children: [], node: text('Image could not be loaded') }]),
-  ])
-}
-
-const renderImage = (state: Readonly<MediaPreviewState>): TreeNode => {
-  const { url } = state
-  return node(
-    VirtualDomElements.Div,
+const renderError = (): readonly VirtualDomNode[] => {
+  return [
     {
-      className: 'MediaPreviewContent',
+      childCount: 1,
+      className: 'MediaPreviewError',
+      type: VirtualDomElements.Div,
     },
-    [
-      node(VirtualDomElements.Div, { className: 'MediaPreviewImageWrapper' }, [
-        node(VirtualDomElements.Img, {
-          alt: '',
-          className: 'MediaPreviewImage',
-          draggable: false,
-          name: 'image',
-          onError: 'handleMediaPreviewImageError',
-          src: url,
-        }),
-      ]),
-    ],
-  )
+    {
+      childCount: 1,
+      type: VirtualDomElements.Span,
+    },
+    text('Image could not be loaded'),
+  ]
+}
+
+const renderImage = (state: Readonly<MediaPreviewState>): readonly VirtualDomNode[] => {
+  const { url } = state
+  return [
+    {
+      childCount: 1,
+      className: 'MediaPreviewContent',
+      type: VirtualDomElements.Div,
+    },
+    {
+      childCount: 1,
+      className: 'MediaPreviewImageWrapper',
+      type: VirtualDomElements.Div,
+    },
+    {
+      alt: '',
+      childCount: 0,
+      className: 'MediaPreviewImage',
+      draggable: false,
+      name: 'image',
+      onError: 'handleMediaPreviewImageError',
+      src: url,
+      type: VirtualDomElements.Img,
+    },
+  ]
 }
 
 export const render = (state: Readonly<MediaPreviewState>): readonly VirtualDomNode[] => {
   const { error, pointerDown } = state
   const className = pointerDown ? 'MediaPreview MediaPreviewDragging' : 'MediaPreview'
-  return flatten(
-    node(
-      VirtualDomElements.Div,
-      {
-        className,
-        onPointerDown: 'handleMediaPreviewPointerDown',
-        onWheel: 'handleMediaPreviewWheel',
-      },
-      [error ? renderError() : renderImage(state)],
-    ),
-  )
+  const content = error ? renderError() : renderImage(state)
+  return [
+    {
+      childCount: 1,
+      className,
+      onPointerDown: 'handleMediaPreviewPointerDown',
+      onWheel: 'handleMediaPreviewWheel',
+      type: VirtualDomElements.Div,
+    },
+    ...content,
+  ]
 }

--- a/packages/extension/src/parts/RenderMediaPreview/RenderMediaPreview.ts
+++ b/packages/extension/src/parts/RenderMediaPreview/RenderMediaPreview.ts
@@ -1,41 +1,49 @@
 import { text, VirtualDomElements, type VirtualDomNode } from '@lvce-editor/virtual-dom-worker'
 import type { MediaPreviewState } from '../MediaPreviewViewInstance/MediaPreviewViewInstance.ts'
 
+const handleMediaPreviewImageError = 'handleMediaPreviewImageError'
+const handleMediaPreviewPointerDown = 'handleMediaPreviewPointerDown'
+const handleMediaPreviewWheel = 'handleMediaPreviewWheel'
+
+const errorNode: VirtualDomNode = {
+  childCount: 1,
+  className: 'MediaPreviewError',
+  type: VirtualDomElements.Div,
+}
+
+const errorMessageNode: VirtualDomNode = {
+  childCount: 1,
+  type: VirtualDomElements.Span,
+}
+
+const contentNode: VirtualDomNode = {
+  childCount: 1,
+  className: 'MediaPreviewContent',
+  type: VirtualDomElements.Div,
+}
+
+const imageWrapperNode: VirtualDomNode = {
+  childCount: 1,
+  className: 'MediaPreviewImageWrapper',
+  type: VirtualDomElements.Div,
+}
+
 const renderError = (): readonly VirtualDomNode[] => {
-  return [
-    {
-      childCount: 1,
-      className: 'MediaPreviewError',
-      type: VirtualDomElements.Div,
-    },
-    {
-      childCount: 1,
-      type: VirtualDomElements.Span,
-    },
-    text('Image could not be loaded'),
-  ]
+  return [errorNode, errorMessageNode, text('Image could not be loaded')]
 }
 
 const renderImage = (state: Readonly<MediaPreviewState>): readonly VirtualDomNode[] => {
   const { url } = state
   return [
-    {
-      childCount: 1,
-      className: 'MediaPreviewContent',
-      type: VirtualDomElements.Div,
-    },
-    {
-      childCount: 1,
-      className: 'MediaPreviewImageWrapper',
-      type: VirtualDomElements.Div,
-    },
+    contentNode,
+    imageWrapperNode,
     {
       alt: '',
       childCount: 0,
       className: 'MediaPreviewImage',
       draggable: false,
       name: 'image',
-      onError: 'handleMediaPreviewImageError',
+      onError: handleMediaPreviewImageError,
       src: url,
       type: VirtualDomElements.Img,
     },
@@ -50,8 +58,8 @@ export const render = (state: Readonly<MediaPreviewState>): readonly VirtualDomN
     {
       childCount: 1,
       className,
-      onPointerDown: 'handleMediaPreviewPointerDown',
-      onWheel: 'handleMediaPreviewWheel',
+      onPointerDown: handleMediaPreviewPointerDown,
+      onWheel: handleMediaPreviewWheel,
       type: VirtualDomElements.Div,
     },
     ...content,

--- a/packages/extension/test/RenderMediaPreview.test.ts
+++ b/packages/extension/test/RenderMediaPreview.test.ts
@@ -49,8 +49,29 @@ test('renders an error without an image', () => {
     error: true,
   })
 
-  expect(dom.some((node) => node.type === VirtualDomElements.Img)).toBe(false)
-  expect(dom.some((node) => node.text === 'Image could not be loaded')).toBe(true)
+  expect(dom).toEqual([
+    {
+      childCount: 1,
+      className: 'MediaPreview',
+      onPointerDown: 'handleMediaPreviewPointerDown',
+      onWheel: 'handleMediaPreviewWheel',
+      type: VirtualDomElements.Div,
+    },
+    {
+      childCount: 1,
+      className: 'MediaPreviewError',
+      type: VirtualDomElements.Div,
+    },
+    {
+      childCount: 1,
+      type: VirtualDomElements.Span,
+    },
+    {
+      childCount: 0,
+      text: 'Image could not be loaded',
+      type: VirtualDomElements.Text,
+    },
+  ])
 })
 
 test('renders the dragging class while the pointer is down', () => {


### PR DESCRIPTION
Summary:
- replace the pseudo-tree renderer and flattening helper with native flat virtual DOM arrays
- preserve explicit child counts and existing media preview behavior
- assert the full error-state virtual DOM structure