### PR TITLE
feature: update extension api to 8.75.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2870,12 +2870,13 @@
       "license": "MIT"
     },
     "node_modules/@lvce-editor/api": {
-      "version": "8.74.0",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/api/-/api-8.74.0.tgz",
-      "integrity": "sha512-BwfNwkHP1W+x00f6HtUbP0LG4c7qFlnamu7ZpYCVT/nmo/1IJBqZfoS4xKAQKdqiGWdJkRsnPDp2HLuEfNzj6w==",
+      "version": "8.75.0",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/api/-/api-8.75.0.tgz",
+      "integrity": "sha512-ub0W95GZVxRmUYpkfGHirV8+UUO15uZCBxkhdgtctzLWuw1SZQO3UEcBqKhTbPsiRCzawclHDXRFR0N9vFGboQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
+        "@lvce-editor/command": "^2.0.0",
         "@lvce-editor/rpc": "^6.4.0",
         "@lvce-editor/rpc-registry": "^9.24.0",
         "@lvce-editor/virtual-dom-worker": "^10.0.0"
@@ -15593,7 +15594,7 @@
       "license": "MIT",
       "devDependencies": {
         "@jest/globals": "^30.4.1",
-        "@lvce-editor/api": "^8.74.0",
+        "@lvce-editor/api": "^8.75.0",
         "@lvce-editor/virtual-dom-worker": "^11.11.2"
       }
     },

--- a/packages/extension/package.json
+++ b/packages/extension/package.json
@@ -33,7 +33,7 @@
   },
   "devDependencies": {
     "@jest/globals": "^30.4.1",
-    "@lvce-editor/api": "^8.74.0",
+    "@lvce-editor/api": "^8.75.0",
     "@lvce-editor/virtual-dom-worker": "^11.11.2"
   }
 }


### PR DESCRIPTION
Summary:

- update @lvce-editor/api from 8.74.0 to 8.75.0
- reduce the media preview main bundle by 21,758 bytes (22.44%) and its packaged archive by 2,891 bytes (13.15%)