### PR TITLE
fix: exclude typescript sources from package

### DIFF
--- a/packages/build/src/build.js
+++ b/packages/build/src/build.js
@@ -19,9 +19,6 @@ fs.writeFileSync(join(root, 'dist', 'package.json'), JSON.stringify(packageJson,
 fs.copyFileSync(join(root, 'README.md'), join(root, 'dist', 'README.md'))
 fs.copyFileSync(join(root, 'LICENSE'), join(root, 'dist', 'LICENSE'))
 fs.copyFileSync(join(extension, 'extension.json'), join(root, 'dist', 'extension.json'))
-fs.cpSync(join(extension, 'src'), join(root, 'dist', 'src'), {
-  recursive: true,
-})
 fs.cpSync(join(extension, 'media'), join(root, 'dist', 'media'), {
   recursive: true,
 })


### PR DESCRIPTION
Remove the build step that copies extension TypeScript sources into the production archive. The package now contains only the compiled extension and required runtime assets, reducing the archive size without changing extension behavior.