### PR TITLE
fix: update dev server websocket issuer support

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3053,9 +3053,9 @@
       "license": "MIT"
     },
     "node_modules/@lvce-editor/extension-host-helper-process": {
-      "version": "0.96.8",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/extension-host-helper-process/-/extension-host-helper-process-0.96.8.tgz",
-      "integrity": "sha512-mPAKlyufGwBmjNMGSi0IG3EqtvP8HLe/Z3N7QqpBTY/eebSvdJm5t7Ctegt8+YBPIe8fwYuYEjhUcl6RHDnMWA==",
+      "version": "0.99.9",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/extension-host-helper-process/-/extension-host-helper-process-0.99.9.tgz",
+      "integrity": "sha512-33ObS+Lu98nhGe7ZkE18CowX07aN0pcD3muW+w/fJeGwvsXwzqFZDXi/jeDmzvyNnptrn3Ccxa8gUZFRygy8bQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3069,9 +3069,9 @@
       }
     },
     "node_modules/@lvce-editor/file-system-process": {
-      "version": "5.11.0",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/file-system-process/-/file-system-process-5.11.0.tgz",
-      "integrity": "sha512-g1rGvTIBggaG9emayBczibKs+eOJgkOtbgp3TidDpuSwaX7uJotLBCGJNQyu6QhPPLskmkz1d5L4R+7bOzO/oA==",
+      "version": "5.12.0",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/file-system-process/-/file-system-process-5.12.0.tgz",
+      "integrity": "sha512-fHn8/9SNNsvTXhekJBCHZ24+ZsBHaisjPep7mipuAeWxTUdN6KTyfY9hpleKPv/VOlA1o4ENueQkNFhoFesftw==",
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -3451,9 +3451,9 @@
       }
     },
     "node_modules/@lvce-editor/search-process": {
-      "version": "15.6.0",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/search-process/-/search-process-15.6.0.tgz",
-      "integrity": "sha512-l6qJZAPFSWxgOyaE21D949s4R7X/cJax7mNH4S09N/TaUqHYnT8ScR5P9lihpn1tDXlI1tAZKC9TZuwhTalOjw==",
+      "version": "15.7.0",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/search-process/-/search-process-15.7.0.tgz",
+      "integrity": "sha512-eAyrQ8TakmyKXffDy0hDcsKVoZ6du44kos4XFeDnedfsd1znIBrsnF6mMplixMdL619Cd90kTXA739B7QMorRg==",
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -3472,14 +3472,14 @@
       }
     },
     "node_modules/@lvce-editor/server": {
-      "version": "0.96.8",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/server/-/server-0.96.8.tgz",
-      "integrity": "sha512-FVXG834717rzPx67k8/BClKDn4e/wJEqJeLrUbZIbUC+yZaNTYnZ9n/g2rRImBFj5uZbOLmZ7VBnS7wdW21REw==",
+      "version": "0.99.9",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/server/-/server-0.99.9.tgz",
+      "integrity": "sha512-3enL9wdcrmWrt8gOraWeEOHHoryID6QidHSxy6R3vwuMKwDSfdK3PbDXHO/XKpYqRIL3V36pwPRp58I5xE4OCQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@lvce-editor/shared-process": "0.96.8",
-        "@lvce-editor/static-server": "0.96.8"
+        "@lvce-editor/shared-process": "0.99.9",
+        "@lvce-editor/static-server": "0.99.9"
       },
       "bin": {
         "server": "bin/server.js"
@@ -3489,14 +3489,14 @@
       }
     },
     "node_modules/@lvce-editor/shared-process": {
-      "version": "0.96.8",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/shared-process/-/shared-process-0.96.8.tgz",
-      "integrity": "sha512-rhK/huIMKoB8wP7rjKYhcfK+6turRqZ0DxwHqO6T8wgF3QwH09vPHJ8rvdCKlbgJhGCRHCJmsNy/jDp5Hc+1tQ==",
+      "version": "0.99.9",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/shared-process/-/shared-process-0.99.9.tgz",
+      "integrity": "sha512-fexawZ0Fyt8PKAD6x+wjWxu5qZydziK8AbPmhJiwWG6jR1e3zaZNu4GnqNkovNUMM+vQa5uYCVQg1cVOocggtg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@lvce-editor/assert": "1.9.0",
-        "@lvce-editor/extension-host-helper-process": "0.96.8",
+        "@lvce-editor/extension-host-helper-process": "0.99.9",
         "@lvce-editor/ipc": "16.10.0",
         "@lvce-editor/json-rpc": "8.6.0",
         "@lvce-editor/jsonc-parser": "1.5.0",
@@ -3513,13 +3513,13 @@
       },
       "optionalDependencies": {
         "@lvce-editor/embeds-process": "4.15.0",
-        "@lvce-editor/file-system-process": "5.11.0",
+        "@lvce-editor/file-system-process": "5.12.0",
         "@lvce-editor/file-watcher-process": "4.12.0",
         "@lvce-editor/network-process": "5.2.0",
         "@lvce-editor/preload": "1.5.0",
         "@lvce-editor/preview-process": "11.0.0",
         "@lvce-editor/pty-host": "8.7.0",
-        "@lvce-editor/search-process": "15.6.0",
+        "@lvce-editor/search-process": "15.7.0",
         "@lvce-editor/typescript-compile-process": "5.8.0",
         "open": "^11.0.0",
         "tail": "^2.2.6",
@@ -3528,9 +3528,9 @@
       }
     },
     "node_modules/@lvce-editor/static-server": {
-      "version": "0.96.8",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/static-server/-/static-server-0.96.8.tgz",
-      "integrity": "sha512-VzS2erZJmRr6mxhWl3dVAwcIutnGQ2Jx/HLRBE+UoiFc5BshS8HlJGmPM+IQ1Xaw0qdaCOcHk3GBfyIF09mdbg==",
+      "version": "0.99.9",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/static-server/-/static-server-0.99.9.tgz",
+      "integrity": "sha512-a689RnmMS2X4UISWuKHHxfv3YYobljvaSnDqDgzR5bhhu/urJ7G+Zwtra/QPqs2k4N9CoF86cyGoniqzv6cFaQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -15531,7 +15531,7 @@
       "license": "MIT",
       "devDependencies": {
         "@lvce-editor/package-extension": "^3.7.0",
-        "@lvce-editor/server": "^0.96.8",
+        "@lvce-editor/server": "^0.99.9",
         "esbuild": "^0.28.1"
       }
     },

--- a/packages/build/package.json
+++ b/packages/build/package.json
@@ -10,7 +10,7 @@
   "license": "MIT",
   "devDependencies": {
     "@lvce-editor/package-extension": "^3.7.0",
-    "@lvce-editor/server": "^0.96.8",
+    "@lvce-editor/server": "^0.99.9",
     "esbuild": "^0.28.1"
   }
 }


### PR DESCRIPTION
Update the media-preview development server to LVCE 0.99.9 so document navigations receive a fresh WebSocket issuer and renderer startup no longer fails on localhost.