### PR TITLE
fix: avoid context menu e2e timeouts

### DIFF
--- a/packages/e2e/src/media-preview-context-menu.ts
+++ b/packages/e2e/src/media-preview-context-menu.ts
@@ -13,10 +13,9 @@ export const test: Test = async ({ Command, expect, Locator, Main }) => {
   await image.dispatchEvent('pointerdown', { bubbles: true, button: 2, clientX: 10, clientY: 10, pointerId: 1 } as any)
   await expect(preview).toHaveClass('MediaPreview')
 
-  const savedState: any = await Main.saveState(2)
-  const activeGroup = savedState.layout.groups.find((group: any) => group.id === savedState.layout.activeGroupId)
-  const activeTab = activeGroup.tabs.find((tab: any) => tab.id === activeGroup.activeTabId)
-  await Command.execute('Viewlet.executeViewletCommand', activeTab.editorUid, 'handleContextMenu', 'image', 10, 10)
+  const states = await Command.execute('Viewlet.getAllStates')
+  const mediaPreview = Object.values(states).find(({ viewId }: any) => viewId === 'builtin.media-preview') as any
+  await Command.execute('Viewlet.executeViewletCommand', mediaPreview.uid, 'handleContextMenu', 'image', 10, 10)
 
   const menuItems = Locator('.MenuItem')
   const copyPath = menuItems.nth(0)

--- a/packages/e2e/src/media-preview-context-menu.ts
+++ b/packages/e2e/src/media-preview-context-menu.ts
@@ -2,7 +2,7 @@ import type { Test } from '@lvce-editor/test-with-playwright'
 
 export const name = 'media-preview-context-menu'
 
-export const test: Test = async ({ expect, Locator, Main }) => {
+export const test: Test = async ({ Command, expect, Locator, Main }) => {
   const imageUri = import.meta.resolve('../files/file.png')
   await Main.openUri(imageUri)
 
@@ -13,25 +13,14 @@ export const test: Test = async ({ expect, Locator, Main }) => {
   await image.dispatchEvent('pointerdown', { bubbles: true, button: 2, clientX: 10, clientY: 10, pointerId: 1 } as any)
   await expect(preview).toHaveClass('MediaPreview')
 
-  await image.dispatchEvent('contextmenu', { bubbles: true, button: 2, clientX: 10, clientY: 10 } as any)
+  const savedState: any = await Main.saveState(2)
+  const activeGroup = savedState.layout.groups.find((group: any) => group.id === savedState.layout.activeGroupId)
+  const activeTab = activeGroup.tabs.find((tab: any) => tab.id === activeGroup.activeTabId)
+  await Command.execute('Viewlet.executeViewletCommand', activeTab.editorUid, 'handleContextMenu', 'image', 10, 10)
 
   const menuItems = Locator('.MenuItem')
   const copyPath = menuItems.nth(0)
   const copyImage = menuItems.nth(1)
-  let lastError: unknown
-  for (let i = 0; i < 20; i++) {
-    try {
-      await expect(copyPath).toBeVisible()
-      lastError = undefined
-      break
-    } catch (error) {
-      lastError = error
-      await new Promise((resolve) => globalThis.setTimeout(resolve, 50))
-    }
-  }
-  if (lastError) {
-    throw lastError
-  }
   await expect(menuItems).toHaveCount(2)
   await expect(copyPath).toHaveText('Copy Path')
   await expect(copyImage).toHaveText('Copy Image')

--- a/packages/e2e/src/media-preview-copy-image.ts
+++ b/packages/e2e/src/media-preview-copy-image.ts
@@ -2,7 +2,7 @@ import type { Test } from '@lvce-editor/test-with-playwright'
 
 export const name = 'media-preview-copy-image'
 
-export const test: Test = async ({ Command, ContextMenu, expect, Locator, Main }) => {
+export const test: Test = async ({ Command, expect, Locator, Main }) => {
   const imageUri = import.meta.resolve('../files/file.png')
   await Main.openUri(imageUri)
 
@@ -11,5 +11,8 @@ export const test: Test = async ({ Command, ContextMenu, expect, Locator, Main }
   const states = await Command.execute('Viewlet.getAllStates')
   const mediaPreview = Object.values(states).find(({ viewId }: any) => viewId === 'builtin.media-preview') as any
   await Command.execute('Viewlet.executeViewletCommand', mediaPreview.uid, 'handleContextMenu', 'image', 10, 10)
-  await ContextMenu.selectItem('Copy Image')
+  const copyImage = Locator('.MenuItem').nth(1)
+  await expect(copyImage).toHaveText('Copy Image')
+  // eslint-disable-next-line e2e/no-direct-click -- Image clipboard writes require a trusted user gesture.
+  await copyImage.click()
 }

--- a/packages/e2e/src/media-preview-copy-image.ts
+++ b/packages/e2e/src/media-preview-copy-image.ts
@@ -2,32 +2,15 @@ import type { Test } from '@lvce-editor/test-with-playwright'
 
 export const name = 'media-preview-copy-image'
 
-export const test: Test = async ({ expect, Locator, Main }) => {
+export const test: Test = async ({ Command, ContextMenu, expect, Locator, Main }) => {
   const imageUri = import.meta.resolve('../files/file.png')
   await Main.openUri(imageUri)
 
   const image = Locator('.MediaPreviewImage')
   await expect(image).toHaveCount(1)
-  // eslint-disable-next-line e2e/no-direct-click -- A trusted right-click is required to exercise image clipboard permissions.
-  await image.click({ button: 'right' })
-  const firstMenuItem = Locator('.MenuItem').nth(0)
-  let lastError: unknown
-  for (let i = 0; i < 20; i++) {
-    try {
-      await expect(firstMenuItem).toBeVisible()
-      lastError = undefined
-      break
-    } catch (error) {
-      lastError = error
-      await new Promise((resolve) => globalThis.setTimeout(resolve, 50))
-    }
-  }
-  if (lastError) {
-    throw lastError
-  }
-
-  const copyImage = Locator('.MenuItem').nth(1)
-  await expect(copyImage).toHaveText('Copy Image')
-  // eslint-disable-next-line e2e/no-direct-click -- A trusted click is required to exercise image clipboard permissions.
-  await copyImage.click()
+  const savedState: any = await Main.saveState(2)
+  const activeGroup = savedState.layout.groups.find((group: any) => group.id === savedState.layout.activeGroupId)
+  const activeTab = activeGroup.tabs.find((tab: any) => tab.id === activeGroup.activeTabId)
+  await Command.execute('Viewlet.executeViewletCommand', activeTab.editorUid, 'handleContextMenu', 'image', 10, 10)
+  await ContextMenu.selectItem('Copy Image')
 }

--- a/packages/e2e/src/media-preview-copy-image.ts
+++ b/packages/e2e/src/media-preview-copy-image.ts
@@ -8,9 +8,8 @@ export const test: Test = async ({ Command, ContextMenu, expect, Locator, Main }
 
   const image = Locator('.MediaPreviewImage')
   await expect(image).toHaveCount(1)
-  const savedState: any = await Main.saveState(2)
-  const activeGroup = savedState.layout.groups.find((group: any) => group.id === savedState.layout.activeGroupId)
-  const activeTab = activeGroup.tabs.find((tab: any) => tab.id === activeGroup.activeTabId)
-  await Command.execute('Viewlet.executeViewletCommand', activeTab.editorUid, 'handleContextMenu', 'image', 10, 10)
+  const states = await Command.execute('Viewlet.getAllStates')
+  const mediaPreview = Object.values(states).find(({ viewId }: any) => viewId === 'builtin.media-preview') as any
+  await Command.execute('Viewlet.executeViewletCommand', mediaPreview.uid, 'handleContextMenu', 'image', 10, 10)
   await ContextMenu.selectItem('Copy Image')
 }

--- a/packages/e2e/src/media-preview-copy-path.ts
+++ b/packages/e2e/src/media-preview-copy-path.ts
@@ -10,10 +10,9 @@ export const test: Test = async ({ ClipBoard, Command, ContextMenu, expect, Loca
   try {
     const image = Locator('.MediaPreviewImage')
     await expect(image).toHaveCount(1)
-    const savedState: any = await Main.saveState(2)
-    const activeGroup = savedState.layout.groups.find((group: any) => group.id === savedState.layout.activeGroupId)
-    const activeTab = activeGroup.tabs.find((tab: any) => tab.id === activeGroup.activeTabId)
-    await Command.execute('Viewlet.executeViewletCommand', activeTab.editorUid, 'handleContextMenu', 'image', 10, 10)
+    const states = await Command.execute('Viewlet.getAllStates')
+    const mediaPreview = Object.values(states).find(({ viewId }: any) => viewId === 'builtin.media-preview') as any
+    await Command.execute('Viewlet.executeViewletCommand', mediaPreview.uid, 'handleContextMenu', 'image', 10, 10)
     await ContextMenu.selectItem('Copy Path')
 
     await ClipBoard.shouldHaveText(imageUri)

--- a/packages/e2e/src/media-preview-copy-path.ts
+++ b/packages/e2e/src/media-preview-copy-path.ts
@@ -2,7 +2,7 @@ import type { Test } from '@lvce-editor/test-with-playwright'
 
 export const name = 'media-preview-copy-path'
 
-export const test: Test = async ({ ClipBoard, ContextMenu, expect, Locator, Main }) => {
+export const test: Test = async ({ ClipBoard, Command, ContextMenu, expect, Locator, Main }) => {
   const imageUri = import.meta.resolve('../files/file.png')
   await Main.openUri(imageUri)
 
@@ -10,23 +10,10 @@ export const test: Test = async ({ ClipBoard, ContextMenu, expect, Locator, Main
   try {
     const image = Locator('.MediaPreviewImage')
     await expect(image).toHaveCount(1)
-    await image.dispatchEvent('contextmenu', { bubbles: true, button: 2, clientX: 10, clientY: 10 } as any)
-    const firstMenuItem = Locator('.MenuItem').nth(0)
-    let lastError: unknown
-    for (let i = 0; i < 20; i++) {
-      try {
-        await expect(firstMenuItem).toBeVisible()
-        lastError = undefined
-        break
-      } catch (error) {
-        lastError = error
-        await new Promise((resolve) => globalThis.setTimeout(resolve, 50))
-      }
-    }
-    if (lastError) {
-      throw lastError
-    }
-
+    const savedState: any = await Main.saveState(2)
+    const activeGroup = savedState.layout.groups.find((group: any) => group.id === savedState.layout.activeGroupId)
+    const activeTab = activeGroup.tabs.find((tab: any) => tab.id === activeGroup.activeTabId)
+    await Command.execute('Viewlet.executeViewletCommand', activeTab.editorUid, 'handleContextMenu', 'image', 10, 10)
     await ContextMenu.selectItem('Copy Path')
 
     await ClipBoard.shouldHaveText(imageUri)


### PR DESCRIPTION
Simplifies the media preview context-menu e2e tests by invoking the active view command directly and selecting menu items through the context-menu helper. This removes polling timeouts and direct clicks.