### PR TITLE
fix: support memfs media previews

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2871,9 +2871,9 @@
       "optional": true
     },
     "node_modules/@lvce-editor/api": {
-      "version": "8.83.2",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/api/-/api-8.83.2.tgz",
-      "integrity": "sha512-D5oS8rC99qiYg+5ZdHd5gzhwxNp7iysDjmmUiDH+3ZSqZ2jgHet45Eh59UrmNbaO27rtKulzcgxlQFjdZfFR8Q==",
+      "version": "8.83.3",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/api/-/api-8.83.3.tgz",
+      "integrity": "sha512-RI5MxdXY+BSM4x4FT6veQDK9/5IDWr1imzDZbFjQ1g39AgzB5sX3dhWqW4kX8bPley7AW93ser+lChplThBdZg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3053,9 +3053,9 @@
       "license": "MIT"
     },
     "node_modules/@lvce-editor/extension-host-helper-process": {
-      "version": "0.99.9",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/extension-host-helper-process/-/extension-host-helper-process-0.99.9.tgz",
-      "integrity": "sha512-33ObS+Lu98nhGe7ZkE18CowX07aN0pcD3muW+w/fJeGwvsXwzqFZDXi/jeDmzvyNnptrn3Ccxa8gUZFRygy8bQ==",
+      "version": "0.99.11",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/extension-host-helper-process/-/extension-host-helper-process-0.99.11.tgz",
+      "integrity": "sha512-epBLFj/vNBp8JL8FU/kWQuq2+OfAul0fZ4yNcxUc8v2fKcqJR5dC7n5v9H5gLjRvdieRVFR3dSqnnu7Q+M+OeA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3472,14 +3472,14 @@
       }
     },
     "node_modules/@lvce-editor/server": {
-      "version": "0.99.9",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/server/-/server-0.99.9.tgz",
-      "integrity": "sha512-3enL9wdcrmWrt8gOraWeEOHHoryID6QidHSxy6R3vwuMKwDSfdK3PbDXHO/XKpYqRIL3V36pwPRp58I5xE4OCQ==",
+      "version": "0.99.11",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/server/-/server-0.99.11.tgz",
+      "integrity": "sha512-HdQFsCHdOEzeXiy4jqmO2jYGPKedDZO88/lvGRmkunjduSAVfx5MiIhQSwEVTGOnVYLUa0dHB459E9BcfYVYkw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@lvce-editor/shared-process": "0.99.9",
-        "@lvce-editor/static-server": "0.99.9"
+        "@lvce-editor/shared-process": "0.99.11",
+        "@lvce-editor/static-server": "0.99.11"
       },
       "bin": {
         "server": "bin/server.js"
@@ -3489,14 +3489,14 @@
       }
     },
     "node_modules/@lvce-editor/shared-process": {
-      "version": "0.99.9",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/shared-process/-/shared-process-0.99.9.tgz",
-      "integrity": "sha512-fexawZ0Fyt8PKAD6x+wjWxu5qZydziK8AbPmhJiwWG6jR1e3zaZNu4GnqNkovNUMM+vQa5uYCVQg1cVOocggtg==",
+      "version": "0.99.11",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/shared-process/-/shared-process-0.99.11.tgz",
+      "integrity": "sha512-HA/a4czyP+jXZHq0Xqp2YAY+P0FYStDSZn7yY7p7ac2rAWMX/Qmh5oyBII2x1qXQ6U4lNGFhq2A6ss3Et50kbg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@lvce-editor/assert": "1.9.0",
-        "@lvce-editor/extension-host-helper-process": "0.99.9",
+        "@lvce-editor/extension-host-helper-process": "0.99.11",
         "@lvce-editor/ipc": "16.10.0",
         "@lvce-editor/json-rpc": "8.6.0",
         "@lvce-editor/jsonc-parser": "1.5.0",
@@ -3528,9 +3528,9 @@
       }
     },
     "node_modules/@lvce-editor/static-server": {
-      "version": "0.99.9",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/static-server/-/static-server-0.99.9.tgz",
-      "integrity": "sha512-a689RnmMS2X4UISWuKHHxfv3YYobljvaSnDqDgzR5bhhu/urJ7G+Zwtra/QPqs2k4N9CoF86cyGoniqzv6cFaQ==",
+      "version": "0.99.11",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/static-server/-/static-server-0.99.11.tgz",
+      "integrity": "sha512-QRyqSceiX5zHrrwfdA81oDcs8j8Bt8yjDPR8nsE+9ygpd9sqZLShq/pBgaSQMUxBrSS0g02GEBM5yoaXzrwMFg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -15518,7 +15518,7 @@
       "license": "MIT",
       "devDependencies": {
         "@lvce-editor/package-extension": "^3.7.0",
-        "@lvce-editor/server": "^0.99.9",
+        "@lvce-editor/server": "^0.99.11",
         "esbuild": "^0.28.1"
       }
     },
@@ -15535,7 +15535,7 @@
       "license": "MIT",
       "devDependencies": {
         "@jest/globals": "^30.4.1",
-        "@lvce-editor/api": "^8.83.2",
+        "@lvce-editor/api": "^8.83.3",
         "@lvce-editor/virtual-dom-worker": "^11.12.0"
       }
     },

--- a/packages/build/package.json
+++ b/packages/build/package.json
@@ -10,7 +10,7 @@
   "license": "MIT",
   "devDependencies": {
     "@lvce-editor/package-extension": "^3.7.0",
-    "@lvce-editor/server": "^0.99.9",
+    "@lvce-editor/server": "^0.99.11",
     "esbuild": "^0.28.1"
   }
 }

--- a/packages/e2e/src/media-preview.ts
+++ b/packages/e2e/src/media-preview.ts
@@ -17,6 +17,8 @@ export const test: Test = async ({ Editor, expect, FileSystem, Locator, Main, Wo
   await Main.openUri(`${tmpDir}/test.svg`)
 
   // assert
-
-  // TODO verify that svg is visible
+  const image = Locator('.MediaPreviewImage')
+  const error = Locator('.MediaPreviewError')
+  await expect(image).toBeVisible()
+  await expect(error).toHaveCount(0)
 }

--- a/packages/extension/package.json
+++ b/packages/extension/package.json
@@ -33,7 +33,7 @@
   },
   "devDependencies": {
     "@jest/globals": "^30.4.1",
-    "@lvce-editor/api": "^8.83.2",
+    "@lvce-editor/api": "^8.83.3",
     "@lvce-editor/virtual-dom-worker": "^11.12.0"
   }
 }


### PR DESCRIPTION
Use the memfs-aware object URL API and preserve media MIME types through the released LVCE server. Add end-to-end coverage that opens a memfs-backed SVG and verifies the image is visible without an error.