### PR TITLE
test: verify copied image contents

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3053,9 +3053,9 @@
       "license": "MIT"
     },
     "node_modules/@lvce-editor/extension-host-helper-process": {
-      "version": "0.99.11",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/extension-host-helper-process/-/extension-host-helper-process-0.99.11.tgz",
-      "integrity": "sha512-epBLFj/vNBp8JL8FU/kWQuq2+OfAul0fZ4yNcxUc8v2fKcqJR5dC7n5v9H5gLjRvdieRVFR3dSqnnu7Q+M+OeA==",
+      "version": "0.99.14",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/extension-host-helper-process/-/extension-host-helper-process-0.99.14.tgz",
+      "integrity": "sha512-cAx5aHgL5IAZf5LpjtSBCsCDOPRdvt8Yi+Loo7oilUekiZ2ZOqd4CJWdPjZIgJv3Lr2SotHjlCdXbYzTb54owg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3472,14 +3472,14 @@
       }
     },
     "node_modules/@lvce-editor/server": {
-      "version": "0.99.11",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/server/-/server-0.99.11.tgz",
-      "integrity": "sha512-HdQFsCHdOEzeXiy4jqmO2jYGPKedDZO88/lvGRmkunjduSAVfx5MiIhQSwEVTGOnVYLUa0dHB459E9BcfYVYkw==",
+      "version": "0.99.14",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/server/-/server-0.99.14.tgz",
+      "integrity": "sha512-Yqql1JBC64Id2dR7HRy3lLrDtQfqgaSBzoa5/n79F4e0SjL2cM7PBlcg9+cVr/e1kTxnYBIQ7SZpo9f6/oMuqw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@lvce-editor/shared-process": "0.99.11",
-        "@lvce-editor/static-server": "0.99.11"
+        "@lvce-editor/shared-process": "0.99.14",
+        "@lvce-editor/static-server": "0.99.14"
       },
       "bin": {
         "server": "bin/server.js"
@@ -3489,14 +3489,14 @@
       }
     },
     "node_modules/@lvce-editor/shared-process": {
-      "version": "0.99.11",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/shared-process/-/shared-process-0.99.11.tgz",
-      "integrity": "sha512-HA/a4czyP+jXZHq0Xqp2YAY+P0FYStDSZn7yY7p7ac2rAWMX/Qmh5oyBII2x1qXQ6U4lNGFhq2A6ss3Et50kbg==",
+      "version": "0.99.14",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/shared-process/-/shared-process-0.99.14.tgz",
+      "integrity": "sha512-nZS0I4ldNVDjQHu+e7LlcdMMLXIN0z1NU77G/e4gmmjvMnR3WjyuKdIHOacaTLjF/LdquCLOtSPgpRi8KrvLrg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@lvce-editor/assert": "1.9.0",
-        "@lvce-editor/extension-host-helper-process": "0.99.11",
+        "@lvce-editor/extension-host-helper-process": "0.99.14",
         "@lvce-editor/ipc": "16.10.0",
         "@lvce-editor/json-rpc": "8.6.0",
         "@lvce-editor/jsonc-parser": "1.5.0",
@@ -3528,9 +3528,9 @@
       }
     },
     "node_modules/@lvce-editor/static-server": {
-      "version": "0.99.11",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/static-server/-/static-server-0.99.11.tgz",
-      "integrity": "sha512-QRyqSceiX5zHrrwfdA81oDcs8j8Bt8yjDPR8nsE+9ygpd9sqZLShq/pBgaSQMUxBrSS0g02GEBM5yoaXzrwMFg==",
+      "version": "0.99.14",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/static-server/-/static-server-0.99.14.tgz",
+      "integrity": "sha512-faufwe0miS1h0K2Z22h8V38o0A2yGRZlndIjfHn2L2YXf+fc0c6xBlpm+XMNpvXcucKR8Dmj6JiMyTrvaFD9Cg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -3538,14 +3538,14 @@
       }
     },
     "node_modules/@lvce-editor/test-with-playwright": {
-      "version": "22.20.0",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/test-with-playwright/-/test-with-playwright-22.20.0.tgz",
-      "integrity": "sha512-6ZVO70l9vjqpwGNfDXrjmUEmIbBWAkCiBMSPVEDg/uDu7dCFaFp/pSb18atwwGa5lL7ygVWTADsgX6sotD//hA==",
+      "version": "22.21.0",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/test-with-playwright/-/test-with-playwright-22.21.0.tgz",
+      "integrity": "sha512-fENK3H3VjlQMZvzgn0KshUiaLkPes7RWlmc3UMxPwx+znqQLdJ6xHDjgGT7Wkbi83FJLz/JDDJVjEOaQdeBngA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@lvce-editor/test-with-playwright-worker": "22.20.0",
-        "@lvce-editor/test-worker": "^17.11.0"
+        "@lvce-editor/test-with-playwright-worker": "22.21.0",
+        "@lvce-editor/test-worker": "^17.12.0"
       },
       "bin": {
         "test-with-playwright": "bin/test-with-playwright.js"
@@ -3555,9 +3555,9 @@
       }
     },
     "node_modules/@lvce-editor/test-with-playwright-worker": {
-      "version": "22.20.0",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/test-with-playwright-worker/-/test-with-playwright-worker-22.20.0.tgz",
-      "integrity": "sha512-sqV8aZcXCiq0M+TdGN9YdvnlZhOH6eMIHMyfUfvZsFLEBlGyoOB7B6pyrmSh3UO/Mwl3gQ+X/EbRpF6CpXxf6g==",
+      "version": "22.21.0",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/test-with-playwright-worker/-/test-with-playwright-worker-22.21.0.tgz",
+      "integrity": "sha512-k6IiWHduJdSM7m1hSuqLapTodjVeuLvluXo7xhrVXP9Ep8r6BiC56nEreBLgI/SutIzK/x3FB25gVG6gYwe3jA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3574,9 +3574,9 @@
       }
     },
     "node_modules/@lvce-editor/test-worker": {
-      "version": "17.11.0",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/test-worker/-/test-worker-17.11.0.tgz",
-      "integrity": "sha512-leUPrcdEfO1aYA7KCfQJdJ/Rji6FCN+M6yqOin0i81wXukdRl66qdGYoXO8eBIpCy2eAAgAMc89S2iw8aOeFfw==",
+      "version": "17.12.1",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/test-worker/-/test-worker-17.12.1.tgz",
+      "integrity": "sha512-zmHIKpcTHRK5UkD99TQfbwRX2HnzyGpiiAIaOm9ZtEQDw0D8IfSwVwFnsyUmca/L7vVpoCWWjj0xN0EdcoU2wQ==",
       "dev": true,
       "license": "MIT"
     },
@@ -15518,7 +15518,7 @@
       "license": "MIT",
       "devDependencies": {
         "@lvce-editor/package-extension": "^3.7.0",
-        "@lvce-editor/server": "^0.99.11",
+        "@lvce-editor/server": "^0.99.14",
         "esbuild": "^0.28.1"
       }
     },
@@ -15526,7 +15526,7 @@
       "version": "0.0.0-dev",
       "license": "MIT",
       "devDependencies": {
-        "@lvce-editor/test-with-playwright": "^22.20.0"
+        "@lvce-editor/test-with-playwright": "^22.21.0"
       }
     },
     "packages/extension": {

--- a/packages/build/package.json
+++ b/packages/build/package.json
@@ -10,7 +10,7 @@
   "license": "MIT",
   "devDependencies": {
     "@lvce-editor/package-extension": "^3.7.0",
-    "@lvce-editor/server": "^0.99.11",
+    "@lvce-editor/server": "^0.99.14",
     "esbuild": "^0.28.1"
   }
 }

--- a/packages/e2e/package.json
+++ b/packages/e2e/package.json
@@ -9,6 +9,6 @@
     "e2e:headless": "node ../../node_modules/@lvce-editor/test-with-playwright/bin/test-with-playwright.js  --only-extension=../../dist --test-path=. --headless"
   },
   "devDependencies": {
-    "@lvce-editor/test-with-playwright": "^22.20.0"
+    "@lvce-editor/test-with-playwright": "^22.21.0"
   }
 }

--- a/packages/e2e/src/media-preview-copy-image.ts
+++ b/packages/e2e/src/media-preview-copy-image.ts
@@ -2,17 +2,24 @@ import type { Test } from '@lvce-editor/test-with-playwright'
 
 export const name = 'media-preview-copy-image'
 
-export const test: Test = async ({ Command, expect, Locator, Main }) => {
+export const test: Test = async ({ ClipBoard, Command, expect, Locator, Main }) => {
   const imageUri = import.meta.resolve('../files/file.png')
   await Main.openUri(imageUri)
 
-  const image = Locator('.MediaPreviewImage')
-  await expect(image).toHaveCount(1)
-  const states = await Command.execute('Viewlet.getAllStates')
-  const mediaPreview = Object.values(states).find(({ viewId }: any) => viewId === 'builtin.media-preview') as any
-  await Command.execute('Viewlet.executeViewletCommand', mediaPreview.uid, 'handleContextMenu', 'image', 10, 10)
-  const copyImage = Locator('.MenuItem').nth(1)
-  await expect(copyImage).toHaveText('Copy Image')
-  // eslint-disable-next-line e2e/no-direct-click -- Image clipboard writes require a trusted user gesture.
-  await copyImage.click()
+  await ClipBoard.enableMemoryClipBoard()
+  try {
+    const image = Locator('.MediaPreviewImage')
+    await expect(image).toHaveCount(1)
+    const states = await Command.execute('Viewlet.getAllStates')
+    const mediaPreview = Object.values(states).find(({ viewId }: any) => viewId === 'builtin.media-preview') as any
+    await Command.execute('Viewlet.executeViewletCommand', mediaPreview.uid, 'handleContextMenu', 'image', 10, 10)
+    const copyImage = Locator('.MenuItem').nth(1)
+    await expect(copyImage).toHaveText('Copy Image')
+    // eslint-disable-next-line e2e/no-direct-click -- Image clipboard writes require a trusted user gesture.
+    await copyImage.click()
+
+    await ClipBoard.shouldHaveImage(imageUri)
+  } finally {
+    await ClipBoard.disableMemoryClipBoard()
+  }
 }


### PR DESCRIPTION
Enables the memory clipboard around the Copy Image e2e flow and verifies the copied Blob byte-for-byte against the source PNG with `ClipBoard.shouldHaveImage`. Updates the test runner and LVCE server dependencies that provide the assertion and memory image command.