### PR TITLE
feature: show image details in status bar

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2871,9 +2871,9 @@
       "optional": true
     },
     "node_modules/@lvce-editor/api": {
-      "version": "9.6.0",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/api/-/api-9.6.0.tgz",
-      "integrity": "sha512-Kwimgn0y3dHhZYmqEjpmWNrMWk6cCg2o8hl0X9S40hi+xgsdPOFECFRRinIDTNCI/0fytKIdCHgNxchwgO02sg==",
+      "version": "9.13.0",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/api/-/api-9.13.0.tgz",
+      "integrity": "sha512-ssRAllqWmSKnUVETMWi2GlOz5wO/zsz/VMpE+z6e4ERDGoJsnPmqHuXlM6YcW1mmqvX7gOmOF/GUvahYsREU7g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -15589,7 +15589,7 @@
       },
       "devDependencies": {
         "@jest/globals": "^30.4.1",
-        "@lvce-editor/api": "^9.6.0",
+        "@lvce-editor/api": "^9.13.0",
         "@lvce-editor/virtual-dom-worker": "^11.12.0",
         "@types/heic-decode": "^2.0.0"
       }

--- a/packages/e2e/src/media-preview-status-bar-items.ts
+++ b/packages/e2e/src/media-preview-status-bar-items.ts
@@ -1,0 +1,22 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'media-preview-status-bar-items'
+
+// The e2e editor currently starts without extension status bar items enabled.
+export const skip = true
+
+export const test: Test = async ({ expect, Locator, Main, Settings }) => {
+  await Settings.update({ 'statusBar.itemsVisible': true })
+  await Main.openUri(import.meta.resolve('../files/file.png'))
+
+  const dimensions = Locator('.StatusBarItem[name="media-preview-dimensions"]')
+  const size = Locator('.StatusBarItem[name="media-preview-size"]')
+  await expect(dimensions).toBeVisible()
+  await expect(dimensions).toHaveText('1 × 1')
+  await expect(size).toBeVisible()
+  await expect(size).toHaveText('873 B')
+
+  await Main.closeAllEditors()
+  await expect(dimensions).toBeHidden()
+  await expect(size).toBeHidden()
+}

--- a/packages/extension/extension.json
+++ b/packages/extension/extension.json
@@ -17,6 +17,10 @@
           "params": ["handleMediaPreviewImageError"]
         },
         {
+          "name": "handleMediaPreviewImageLoad",
+          "params": ["handleMediaPreviewImageLoad", "event.target.naturalWidth", "event.target.naturalHeight"]
+        },
+        {
           "name": "handleMediaPreviewPointerDown",
           "params": ["handleMediaPreviewPointerDown", "event.button", "event.clientX", "event.clientY"],
           "preventDefault": true,

--- a/packages/extension/package.json
+++ b/packages/extension/package.json
@@ -33,7 +33,7 @@
   },
   "devDependencies": {
     "@jest/globals": "^30.4.1",
-    "@lvce-editor/api": "^9.6.0",
+    "@lvce-editor/api": "^9.13.0",
     "@lvce-editor/virtual-dom-worker": "^11.12.0",
     "@types/heic-decode": "^2.0.0"
   },

--- a/packages/extension/src/parts/FormatBytes/FormatBytes.ts
+++ b/packages/extension/src/parts/FormatBytes/FormatBytes.ts
@@ -1,0 +1,18 @@
+const units = ['B', 'kB', 'MB', 'GB', 'TB', 'PB'] as const
+
+export const formatBytes = (size: number): string => {
+  if (!Number.isFinite(size) || size <= 0) {
+    return '0 B'
+  }
+  let value = size
+  let unitIndex = 0
+  while (value >= 1024 && unitIndex < units.length - 1) {
+    value /= 1024
+    unitIndex++
+  }
+  if (unitIndex === 0) {
+    return `${Math.trunc(value)} ${units[unitIndex]}`
+  }
+  const formatted = value >= 10 ? value.toFixed(0) : value.toFixed(1)
+  return `${formatted} ${units[unitIndex]}`
+}

--- a/packages/extension/src/parts/GetFileSize/GetFileSize.ts
+++ b/packages/extension/src/parts/GetFileSize/GetFileSize.ts
@@ -1,0 +1,16 @@
+import { readFileAsBlob } from '@lvce-editor/api'
+
+type ReadFileAsBlob = (uri: string) => Promise<Blob>
+
+export const getFileSizeWithDependency = async (uri: string, readBlob: ReadFileAsBlob): Promise<number> => {
+  try {
+    const blob = await readBlob(uri)
+    return blob.size
+  } catch {
+    return 0
+  }
+}
+
+export const getFileSize = (uri: string): Promise<number> => {
+  return getFileSizeWithDependency(uri, readFileAsBlob)
+}

--- a/packages/extension/src/parts/MediaPreview/MediaPreview.ts
+++ b/packages/extension/src/parts/MediaPreview/MediaPreview.ts
@@ -42,6 +42,7 @@ const wrapCommand = (fn: (id: number, ...params: readonly any[]) => unknown) => 
 }
 
 export { getUrl } from '../GetUrl/GetUrl.ts'
+export { getFileSize } from '../GetFileSize/GetFileSize.ts'
 export { saveState } from '../SaveState/SaveState.ts'
 export { setSavedState } from '../SetSavedState/SetSavedState.ts'
 export const handleError = wrapCommand(HandleError.handleError)

--- a/packages/extension/src/parts/MediaPreviewView/MediaPreviewView.ts
+++ b/packages/extension/src/parts/MediaPreviewView/MediaPreviewView.ts
@@ -13,6 +13,10 @@ export const view: View<MediaPreviewViewInstance> = {
       params: ['handleMediaPreviewImageError'],
     },
     {
+      name: 'handleMediaPreviewImageLoad',
+      params: ['handleMediaPreviewImageLoad', 'event.target.naturalWidth', 'event.target.naturalHeight'],
+    },
+    {
       name: 'handleMediaPreviewPointerDown',
       params: ['handleMediaPreviewPointerDown', 'event.button', 'event.clientX', 'event.clientY'],
       preventDefault: true,

--- a/packages/extension/src/parts/MediaPreviewViewInstance/MediaPreviewViewInstance.ts
+++ b/packages/extension/src/parts/MediaPreviewViewInstance/MediaPreviewViewInstance.ts
@@ -1,14 +1,18 @@
-import type { MenuEntry, ViewContext, ViewEvent, VirtualDomViewInstance } from '@lvce-editor/api'
+import type { MenuEntry, StatusBarItem, ViewContext, ViewEvent, VirtualDomViewInstance } from '@lvce-editor/api'
 import type { VirtualDomNode } from '@lvce-editor/virtual-dom-worker'
 import { getCss } from '../GetCss/GetCss.ts'
 import * as MediaPreview from '../MediaPreview/MediaPreview.ts'
 import { render } from '../RenderMediaPreview/RenderMediaPreview.ts'
+import { renderStatusBarItems } from '../RenderStatusBarItems/RenderStatusBarItems.ts'
 
 export interface MediaPreviewState {
   readonly domMatrixString: string
   readonly error: boolean
+  readonly fileSize: number
+  readonly height: number
   readonly pointerDown: boolean
   readonly url: string
+  readonly width: number
 }
 
 interface MediaPreviewViewContext extends ViewContext {
@@ -19,18 +23,21 @@ export interface MediaPreviewViewInstance extends VirtualDomViewInstance {
   readonly getCss: () => string
   readonly getMenuEntries: (menuId: string) => Promise<readonly MenuEntry[]>
   readonly handleMediaPreviewImageError: () => void
+  readonly handleMediaPreviewImageLoad: (width: unknown, height: unknown) => void
   readonly handleMediaPreviewPointerDown: (button: unknown, x: unknown, y: unknown) => void
   readonly handleMediaPreviewPointerMove: (x: unknown, y: unknown) => void
   readonly handleMediaPreviewPointerUp: (x: unknown, y: unknown) => void
   readonly handleMediaPreviewWheel: (deltaY: unknown, deltaMode: unknown) => void
   readonly render: () => readonly VirtualDomNode[]
+  readonly renderStatusBarItems: () => readonly StatusBarItem[]
   readonly saveState: () => Promise<unknown>
 }
 
 interface MediaPreviewApi {
   readonly create: (id: number) => unknown
   readonly dispose: (id: number) => unknown
-  readonly getState: (id: number) => Omit<MediaPreviewState, 'url'>
+  readonly getFileSize: (uri: string) => Promise<number>
+  readonly getState: (id: number) => Pick<MediaPreviewState, 'domMatrixString' | 'error' | 'pointerDown'>
   readonly getUrl: (uri: string) => Promise<string>
   readonly handleError: (id: number) => Partial<MediaPreviewState>
   readonly handlePointerDown: (id: number, x: number, y: number) => Partial<MediaPreviewState>
@@ -65,11 +72,14 @@ export const createInstanceWithApi = async (
   api.create(id)
   api.setSavedState(id, context?.state)
   const previewState = api.getState(id)
-  const url = uri ? await api.getUrl(uri) : ''
+  const [url, fileSize] = uri ? await Promise.all([api.getUrl(uri), api.getFileSize(uri)]) : ['', 0]
   let state: MediaPreviewState = {
     ...previewState,
     error: !url || previewState.error,
+    fileSize,
+    height: 0,
     url,
+    width: 0,
   }
 
   const updateState = (newState: Partial<MediaPreviewState>): void => {
@@ -139,6 +149,12 @@ export const createInstanceWithApi = async (
     handleMediaPreviewImageError(): void {
       updateState(api.handleError(id))
     },
+    handleMediaPreviewImageLoad(width: unknown, height: unknown): void {
+      updateState({
+        height: getNumber(height),
+        width: getNumber(width),
+      })
+    },
     handleMediaPreviewPointerDown(button: unknown, x: unknown, y: unknown): void {
       if (button !== 0) {
         return
@@ -156,6 +172,9 @@ export const createInstanceWithApi = async (
     },
     render(): readonly VirtualDomNode[] {
       return render(state)
+    },
+    renderStatusBarItems(): readonly StatusBarItem[] {
+      return renderStatusBarItems(state)
     },
     async saveState(): Promise<unknown> {
       const savedState = api.saveState(id)

--- a/packages/extension/src/parts/RenderMediaPreview/RenderMediaPreview.ts
+++ b/packages/extension/src/parts/RenderMediaPreview/RenderMediaPreview.ts
@@ -2,6 +2,7 @@ import { text, VirtualDomElements, type VirtualDomNode } from '@lvce-editor/virt
 import type { MediaPreviewState } from '../MediaPreviewViewInstance/MediaPreviewViewInstance.ts'
 
 const handleMediaPreviewImageError = 'handleMediaPreviewImageError'
+const handleMediaPreviewImageLoad = 'handleMediaPreviewImageLoad'
 const handleContextMenu = 'handleContextMenu'
 const handleMediaPreviewPointerDown = 'handleMediaPreviewPointerDown'
 const handleMediaPreviewWheel = 'handleMediaPreviewWheel'
@@ -46,6 +47,7 @@ const renderImage = (state: Readonly<MediaPreviewState>): readonly VirtualDomNod
       name: 'image',
       onContextMenu: handleContextMenu,
       onError: handleMediaPreviewImageError,
+      onLoad: handleMediaPreviewImageLoad,
       src: url,
       type: VirtualDomElements.Img,
     },

--- a/packages/extension/src/parts/RenderStatusBarItems/RenderStatusBarItems.ts
+++ b/packages/extension/src/parts/RenderStatusBarItems/RenderStatusBarItems.ts
@@ -1,0 +1,23 @@
+import type { StatusBarItem } from '@lvce-editor/api'
+import type { MediaPreviewState } from '../MediaPreviewViewInstance/MediaPreviewViewInstance.ts'
+import { formatBytes } from '../FormatBytes/FormatBytes.ts'
+
+export const renderStatusBarItems = (state: Readonly<MediaPreviewState>): readonly StatusBarItem[] => {
+  const { fileSize, height, width } = state
+  const dimensions = width > 0 && height > 0 ? `${width} × ${height}` : '— × —'
+  const size = formatBytes(fileSize)
+  return [
+    {
+      ariaLabel: width > 0 && height > 0 ? `Image dimensions: ${width} by ${height} pixels` : 'Image dimensions unavailable',
+      name: 'media-preview-dimensions',
+      text: dimensions,
+      title: 'Image dimensions',
+    },
+    {
+      ariaLabel: `Image size: ${size}`,
+      name: 'media-preview-size',
+      text: size,
+      title: 'Image size',
+    },
+  ]
+}

--- a/packages/extension/test/FormatBytes.test.ts
+++ b/packages/extension/test/FormatBytes.test.ts
@@ -1,0 +1,12 @@
+import { expect, test } from '@jest/globals'
+import { formatBytes } from '../src/parts/FormatBytes/FormatBytes.ts'
+
+test.each([
+  [0, '0 B'],
+  [512, '512 B'],
+  [1536, '1.5 kB'],
+  [12 * 1024 * 1024, '12 MB'],
+  [NaN, '0 B'],
+])('formats %s bytes as %s', (size, expected) => {
+  expect(formatBytes(size)).toBe(expected)
+})

--- a/packages/extension/test/GetFileSize.test.ts
+++ b/packages/extension/test/GetFileSize.test.ts
@@ -1,0 +1,21 @@
+import { beforeEach, expect, jest, test } from '@jest/globals'
+import { getFileSizeWithDependency } from '../src/parts/GetFileSize/GetFileSize.ts'
+
+const readFileAsBlob = jest.fn<(uri: string) => Promise<Blob>>()
+
+beforeEach(() => {
+  jest.resetAllMocks()
+})
+
+test('returns the blob byte size', async () => {
+  readFileAsBlob.mockResolvedValue(new Blob(['hello']))
+
+  await expect(getFileSizeWithDependency('file:///workspace/image.png', readFileAsBlob)).resolves.toBe(5)
+  expect(readFileAsBlob).toHaveBeenCalledWith('file:///workspace/image.png')
+})
+
+test('returns zero when the image cannot be read', async () => {
+  readFileAsBlob.mockRejectedValue(new Error('File not found'))
+
+  await expect(getFileSizeWithDependency('file:///workspace/missing.png', readFileAsBlob)).resolves.toBe(0)
+})

--- a/packages/extension/test/MediaPreviewView.test.ts
+++ b/packages/extension/test/MediaPreviewView.test.ts
@@ -7,6 +7,7 @@ test('contributes a virtual dom media preview view', () => {
   expect(view.create).toBeDefined()
   expect(view.eventListeners?.map((listener) => listener.name)).toEqual([
     'handleMediaPreviewImageError',
+    'handleMediaPreviewImageLoad',
     'handleMediaPreviewPointerDown',
     'handleMediaPreviewPointerMove',
     'handleMediaPreviewPointerUp',

--- a/packages/extension/test/MediaPreviewViewInstance.test.ts
+++ b/packages/extension/test/MediaPreviewViewInstance.test.ts
@@ -12,6 +12,7 @@ const createApi = () => {
   return {
     create: jest.fn((_id: number) => {}),
     dispose: jest.fn((_id: number) => {}),
+    getFileSize: jest.fn(async (_uri: string) => 512_596),
     getState: jest.fn((_id: number) => initialState),
     getUrl: jest.fn(async (_uri: string) => 'blob:https://example.com/image-id'),
     handleError: jest.fn((_id: number) => ({ ...initialState, error: true })),
@@ -38,6 +39,7 @@ test('creates a preview and renders its image', async () => {
   expect(api.create).toHaveBeenCalledWith(7)
   expect(api.setSavedState).toHaveBeenCalledWith(7, undefined)
   expect(api.getState).toHaveBeenCalledWith(7)
+  expect(api.getFileSize).toHaveBeenCalledWith('/workspace/image.png')
   expect(api.getUrl).toHaveBeenCalledWith('/workspace/image.png')
   expect(instance.render().some((node) => node.src === 'blob:https://example.com/image-id')).toBe(true)
   expect(instance.getCss()).toBe(`.MediaPreview {
@@ -77,6 +79,7 @@ test('uses defaults when the view context is missing', async () => {
   expect(api.create).toHaveBeenCalledWith(0)
   expect(api.setSavedState).toHaveBeenCalledWith(0, undefined)
   expect(api.getUrl).not.toHaveBeenCalled()
+  expect(api.getFileSize).not.toHaveBeenCalled()
   expect(instance.render().some((node) => node.text === 'Image could not be loaded')).toBe(true)
 })
 
@@ -100,6 +103,44 @@ test('forwards pointer and image events to the media preview api', async () => {
   instance.handleMediaPreviewImageError()
   expect(api.handleError).toHaveBeenCalledWith(7)
   expect(instance.render().some((node) => node.text === 'Image could not be loaded')).toBe(true)
+})
+
+test('renders image dimensions and file size as status bar items', async () => {
+  const api = createApi()
+  const instance = await createInstanceWithApi(context, api)
+
+  expect(instance.renderStatusBarItems()).toEqual([
+    {
+      ariaLabel: 'Image dimensions unavailable',
+      name: 'media-preview-dimensions',
+      text: '— × —',
+      title: 'Image dimensions',
+    },
+    {
+      ariaLabel: 'Image size: 501 kB',
+      name: 'media-preview-size',
+      text: '501 kB',
+      title: 'Image size',
+    },
+  ])
+
+  instance.handleMediaPreviewImageLoad(640, 480)
+
+  expect(instance.renderStatusBarItems()[0]).toEqual({
+    ariaLabel: 'Image dimensions: 640 by 480 pixels',
+    name: 'media-preview-dimensions',
+    text: '640 × 480',
+    title: 'Image dimensions',
+  })
+})
+
+test('normalizes invalid image dimensions', async () => {
+  const api = createApi()
+  const instance = await createInstanceWithApi(context, api)
+
+  instance.handleMediaPreviewImageLoad(Infinity, '480')
+
+  expect(instance.renderStatusBarItems()[0]?.text).toBe('— × —')
 })
 
 test('only starts dragging for the left mouse button', async () => {

--- a/packages/extension/test/RenderMediaPreview.test.ts
+++ b/packages/extension/test/RenderMediaPreview.test.ts
@@ -5,8 +5,11 @@ import { render } from '../src/parts/RenderMediaPreview/RenderMediaPreview.ts'
 const state = {
   domMatrixString: 'matrix(1, 0, 0, 1, 10, 20)',
   error: false,
+  fileSize: 873,
+  height: 1,
   pointerDown: false,
   url: '/remote/image.png',
+  width: 1,
 }
 
 test('renders the image inside a wrapper', () => {
@@ -38,6 +41,7 @@ test('renders the image inside a wrapper', () => {
       name: 'image',
       onContextMenu: 'handleContextMenu',
       onError: 'handleMediaPreviewImageError',
+      onLoad: 'handleMediaPreviewImageLoad',
       src: '/remote/image.png',
       type: VirtualDomElements.Img,
     },

--- a/packages/extension/test/RenderStatusBarItems.test.ts
+++ b/packages/extension/test/RenderStatusBarItems.test.ts
@@ -1,0 +1,29 @@
+import { expect, test } from '@jest/globals'
+import { renderStatusBarItems } from '../src/parts/RenderStatusBarItems/RenderStatusBarItems.ts'
+
+test('renders image metadata as two status bar items', () => {
+  expect(
+    renderStatusBarItems({
+      domMatrixString: '',
+      error: false,
+      fileSize: 873,
+      height: 480,
+      pointerDown: false,
+      url: '',
+      width: 640,
+    }),
+  ).toEqual([
+    {
+      ariaLabel: 'Image dimensions: 640 by 480 pixels',
+      name: 'media-preview-dimensions',
+      text: '640 × 480',
+      title: 'Image dimensions',
+    },
+    {
+      ariaLabel: 'Image size: 873 B',
+      name: 'media-preview-size',
+      text: '873 B',
+      title: 'Image size',
+    },
+  ])
+})


### PR DESCRIPTION
Shows two view-scoped status bar items for image dimensions and formatted file size. Image load metadata refreshes automatically, and the items are removed with the preview view lifecycle.