### PR TITLE
feature: prefer context menu selection

### DIFF
--- a/packages/e2e/src/media-preview-copy-image.ts
+++ b/packages/e2e/src/media-preview-copy-image.ts
@@ -2,7 +2,7 @@ import type { Test } from '@lvce-editor/test-with-playwright'
 
 export const name = 'media-preview-copy-image'
 
-export const test: Test = async ({ ClipBoard, Command, expect, Locator, Main }) => {
+export const test: Test = async ({ ClipBoard, Command, ContextMenu, expect, Locator, Main }) => {
   const imageUri = import.meta.resolve('../files/file.png')
   await Main.openUri(imageUri)
 
@@ -13,10 +13,7 @@ export const test: Test = async ({ ClipBoard, Command, expect, Locator, Main }) 
     const states = await Command.execute('Viewlet.getAllStates')
     const mediaPreview = Object.values(states).find(({ viewId }: any) => viewId === 'builtin.media-preview') as any
     await Command.execute('Viewlet.executeViewletCommand', mediaPreview.uid, 'handleContextMenu', 'image', 10, 10)
-    const copyImage = Locator('.MenuItem').nth(1)
-    await expect(copyImage).toHaveText('Copy Image')
-    // eslint-disable-next-line e2e/no-direct-click -- Image clipboard writes require a trusted user gesture.
-    await copyImage.click()
+    await ContextMenu.selectItem('Copy Image')
 
     await ClipBoard.shouldHaveImage(imageUri)
   } finally {


### PR DESCRIPTION
Use the ContextMenu page object to select Copy Image in the media preview e2e test.