### PR TITLE
fix: distinguish missing media previews

### DIFF
--- a/packages/e2e/src/media-preview-error-dom-structure.ts
+++ b/packages/e2e/src/media-preview-error-dom-structure.ts
@@ -11,6 +11,6 @@ export const test: Test = async ({ expect, FileSystem, Locator, Main }) => {
   const image = Locator('.MediaPreviewImage')
   await expect(error).toHaveCount(1)
   await expect(message).toHaveCount(1)
-  await expect(message).toHaveText('Image could not be loaded')
+  await expect(message).toHaveText('Image could not be found')
   await expect(image).toHaveCount(0)
 }

--- a/packages/e2e/src/media-preview-missing-avif-error.ts
+++ b/packages/e2e/src/media-preview-missing-avif-error.ts
@@ -8,6 +8,6 @@ export const test: Test = async ({ expect, FileSystem, Locator, Main }) => {
 
   const error = Locator('.MediaPreviewError')
   const image = Locator('.MediaPreviewImage')
-  await expect(error).toHaveText('Image could not be loaded')
+  await expect(error).toHaveText('Image could not be found')
   await expect(image).toHaveCount(0)
 }

--- a/packages/e2e/src/media-preview-missing-file-error.ts
+++ b/packages/e2e/src/media-preview-missing-file-error.ts
@@ -8,5 +8,5 @@ export const test: Test = async ({ expect, FileSystem, Locator, Main }) => {
 
   const error = Locator('.MediaPreviewError')
   await expect(error).toBeVisible()
-  await expect(error).toHaveText('Image could not be loaded')
+  await expect(error).toHaveText('Image could not be found')
 }

--- a/packages/e2e/src/media-preview-missing-gif-error.ts
+++ b/packages/e2e/src/media-preview-missing-gif-error.ts
@@ -8,6 +8,6 @@ export const test: Test = async ({ expect, FileSystem, Locator, Main }) => {
 
   const error = Locator('.MediaPreviewError')
   const image = Locator('.MediaPreviewImage')
-  await expect(error).toHaveText('Image could not be loaded')
+  await expect(error).toHaveText('Image could not be found')
   await expect(image).toHaveCount(0)
 }

--- a/packages/e2e/src/media-preview-missing-heic-error.ts
+++ b/packages/e2e/src/media-preview-missing-heic-error.ts
@@ -8,6 +8,6 @@ export const test: Test = async ({ expect, FileSystem, Locator, Main }) => {
 
   const error = Locator('.MediaPreviewError')
   const image = Locator('.MediaPreviewImage')
-  await expect(error).toHaveText('Image could not be loaded')
+  await expect(error).toHaveText('Image could not be found')
   await expect(image).toHaveCount(0)
 }

--- a/packages/e2e/src/media-preview-missing-ico-error.ts
+++ b/packages/e2e/src/media-preview-missing-ico-error.ts
@@ -8,6 +8,6 @@ export const test: Test = async ({ expect, FileSystem, Locator, Main }) => {
 
   const error = Locator('.MediaPreviewError')
   const image = Locator('.MediaPreviewImage')
-  await expect(error).toHaveText('Image could not be loaded')
+  await expect(error).toHaveText('Image could not be found')
   await expect(image).toHaveCount(0)
 }

--- a/packages/e2e/src/media-preview-missing-jpeg-error.ts
+++ b/packages/e2e/src/media-preview-missing-jpeg-error.ts
@@ -8,6 +8,6 @@ export const test: Test = async ({ expect, FileSystem, Locator, Main }) => {
 
   const error = Locator('.MediaPreviewError')
   const image = Locator('.MediaPreviewImage')
-  await expect(error).toHaveText('Image could not be loaded')
+  await expect(error).toHaveText('Image could not be found')
   await expect(image).toHaveCount(0)
 }

--- a/packages/e2e/src/media-preview-missing-jpg-error.ts
+++ b/packages/e2e/src/media-preview-missing-jpg-error.ts
@@ -8,5 +8,5 @@ export const test: Test = async ({ expect, FileSystem, Locator, Main }) => {
 
   const error = Locator('.MediaPreviewError')
   await expect(error).toBeVisible()
-  await expect(error).toHaveText('Image could not be loaded')
+  await expect(error).toHaveText('Image could not be found')
 }

--- a/packages/e2e/src/media-preview-missing-svg-error.ts
+++ b/packages/e2e/src/media-preview-missing-svg-error.ts
@@ -8,6 +8,6 @@ export const test: Test = async ({ expect, FileSystem, Locator, Main }) => {
 
   const error = Locator('.MediaPreviewError')
   const image = Locator('.MediaPreviewImage')
-  await expect(error).toHaveText('Image could not be loaded')
+  await expect(error).toHaveText('Image could not be found')
   await expect(image).toHaveCount(0)
 }

--- a/packages/e2e/src/media-preview-missing-uppercase-heic-error.ts
+++ b/packages/e2e/src/media-preview-missing-uppercase-heic-error.ts
@@ -8,6 +8,6 @@ export const test: Test = async ({ expect, FileSystem, Locator, Main }) => {
 
   const error = Locator('.MediaPreviewError')
   const image = Locator('.MediaPreviewImage')
-  await expect(error).toHaveText('Image could not be loaded')
+  await expect(error).toHaveText('Image could not be found')
   await expect(image).toHaveCount(0)
 }

--- a/packages/e2e/src/media-preview-missing-webp-error.ts
+++ b/packages/e2e/src/media-preview-missing-webp-error.ts
@@ -8,6 +8,6 @@ export const test: Test = async ({ expect, FileSystem, Locator, Main }) => {
 
   const error = Locator('.MediaPreviewError')
   const image = Locator('.MediaPreviewImage')
-  await expect(error).toHaveText('Image could not be loaded')
+  await expect(error).toHaveText('Image could not be found')
   await expect(image).toHaveCount(0)
 }

--- a/packages/extension/src/parts/MediaPreview/MediaPreview.ts
+++ b/packages/extension/src/parts/MediaPreview/MediaPreview.ts
@@ -43,6 +43,7 @@ const wrapCommand = (fn: (id: number, ...params: readonly any[]) => unknown) => 
 
 export { getUrl } from '../GetUrl/GetUrl.ts'
 export { getFileSize } from '../GetFileSize/GetFileSize.ts'
+export { exists } from '@lvce-editor/api'
 export { saveState } from '../SaveState/SaveState.ts'
 export { setSavedState } from '../SetSavedState/SetSavedState.ts'
 export const handleError = wrapCommand(HandleError.handleError)

--- a/packages/extension/src/parts/MediaPreviewViewInstance/MediaPreviewViewInstance.ts
+++ b/packages/extension/src/parts/MediaPreviewViewInstance/MediaPreviewViewInstance.ts
@@ -8,6 +8,7 @@ import { renderStatusBarItems } from '../RenderStatusBarItems/RenderStatusBarIte
 export interface MediaPreviewState {
   readonly domMatrixString: string
   readonly error: boolean
+  readonly errorMessage: string
   readonly fileSize: number
   readonly height: number
   readonly pointerDown: boolean
@@ -22,7 +23,7 @@ interface MediaPreviewViewContext extends ViewContext {
 export interface MediaPreviewViewInstance extends VirtualDomViewInstance {
   readonly getCss: () => string
   readonly getMenuEntries: (menuId: string) => Promise<readonly MenuEntry[]>
-  readonly handleMediaPreviewImageError: () => void
+  readonly handleMediaPreviewImageError: () => Promise<void>
   readonly handleMediaPreviewImageLoad: (width: unknown, height: unknown) => void
   readonly handleMediaPreviewPointerDown: (button: unknown, x: unknown, y: unknown) => void
   readonly handleMediaPreviewPointerMove: (x: unknown, y: unknown) => void
@@ -36,6 +37,7 @@ export interface MediaPreviewViewInstance extends VirtualDomViewInstance {
 interface MediaPreviewApi {
   readonly create: (id: number) => unknown
   readonly dispose: (id: number) => unknown
+  readonly exists: (uri: string) => Promise<boolean>
   readonly getFileSize: (uri: string) => Promise<number>
   readonly getState: (id: number) => Pick<MediaPreviewState, 'domMatrixString' | 'error' | 'pointerDown'>
   readonly getUrl: (uri: string) => Promise<string>
@@ -61,6 +63,19 @@ const getNumber = (value: unknown): number => {
 }
 
 const imageMenuId = 'mediaPreview.image'
+const imageCouldNotBeFound = 'Image could not be found'
+const imageCouldNotBeLoaded = 'Image could not be loaded'
+
+const getImageErrorMessage = async (uri: string, exists: MediaPreviewApi['exists']): Promise<string> => {
+  if (!uri) {
+    return imageCouldNotBeLoaded
+  }
+  try {
+    return (await exists(uri)) ? imageCouldNotBeLoaded : imageCouldNotBeFound
+  } catch {
+    return imageCouldNotBeLoaded
+  }
+}
 
 export const createInstanceWithApi = async (
   context: ViewContext | undefined,
@@ -73,9 +88,12 @@ export const createInstanceWithApi = async (
   api.setSavedState(id, context?.state)
   const previewState = api.getState(id)
   const [url, fileSize] = uri ? await Promise.all([api.getUrl(uri), api.getFileSize(uri)]) : ['', 0]
+  const error = !url || previewState.error
+  const errorMessage = error ? await getImageErrorMessage(uri, api.exists) : ''
   let state: MediaPreviewState = {
     ...previewState,
-    error: !url || previewState.error,
+    error,
+    errorMessage,
     fileSize,
     height: 0,
     url,
@@ -87,6 +105,14 @@ export const createInstanceWithApi = async (
       ...state,
       ...newState,
     }
+  }
+
+  const handleImageError = async (): Promise<void> => {
+    const errorMessage = await getImageErrorMessage(uri, api.exists)
+    updateState({
+      ...api.handleError(id),
+      errorMessage,
+    })
   }
 
   return {
@@ -119,7 +145,7 @@ export const createInstanceWithApi = async (
     },
     async handleEvent(event: Readonly<ViewEvent>): Promise<void> {
       if (event.type === 'error') {
-        updateState(api.handleError(id))
+        await handleImageError()
         return
       }
       if (event.type !== 'contextmenu') {
@@ -146,8 +172,8 @@ export const createInstanceWithApi = async (
           break
       }
     },
-    handleMediaPreviewImageError(): void {
-      updateState(api.handleError(id))
+    async handleMediaPreviewImageError(): Promise<void> {
+      await handleImageError()
     },
     handleMediaPreviewImageLoad(width: unknown, height: unknown): void {
       updateState({

--- a/packages/extension/src/parts/RenderMediaPreview/RenderMediaPreview.ts
+++ b/packages/extension/src/parts/RenderMediaPreview/RenderMediaPreview.ts
@@ -30,8 +30,9 @@ const imageWrapperNode: VirtualDomNode = {
   type: VirtualDomElements.Div,
 }
 
-const renderError = (): readonly VirtualDomNode[] => {
-  return [errorNode, errorMessageNode, text('Image could not be loaded')]
+const renderError = (state: Readonly<MediaPreviewState>): readonly VirtualDomNode[] => {
+  const { errorMessage } = state
+  return [errorNode, errorMessageNode, text(errorMessage)]
 }
 
 const renderImage = (state: Readonly<MediaPreviewState>): readonly VirtualDomNode[] => {
@@ -57,7 +58,7 @@ const renderImage = (state: Readonly<MediaPreviewState>): readonly VirtualDomNod
 export const render = (state: Readonly<MediaPreviewState>): readonly VirtualDomNode[] => {
   const { error, pointerDown } = state
   const className = pointerDown ? 'MediaPreview MediaPreviewDragging' : 'MediaPreview'
-  const content = error ? renderError() : renderImage(state)
+  const content = error ? renderError(state) : renderImage(state)
   return [
     {
       childCount: 1,

--- a/packages/extension/test/MediaPreviewViewInstance.test.ts
+++ b/packages/extension/test/MediaPreviewViewInstance.test.ts
@@ -12,6 +12,7 @@ const createApi = () => {
   return {
     create: jest.fn((_id: number) => {}),
     dispose: jest.fn((_id: number) => {}),
+    exists: jest.fn(async (_uri: string) => true),
     getFileSize: jest.fn(async (_uri: string) => 512_596),
     getState: jest.fn((_id: number) => initialState),
     getUrl: jest.fn(async (_uri: string) => 'blob:https://example.com/image-id'),
@@ -47,8 +48,29 @@ test('creates a preview and renders its image', async () => {
 }`)
 })
 
-test('renders an error when the image URL cannot be read', async () => {
+test('renders a load error when the image URL cannot be read but the file exists', async () => {
   const api = createApi()
+  api.getUrl.mockResolvedValue('')
+
+  const instance = await createInstanceWithApi(context, api)
+
+  expect(api.exists).toHaveBeenCalledWith('/workspace/image.png')
+  expect(instance.render().some((node) => node.text === 'Image could not be loaded')).toBe(true)
+})
+
+test('renders a not found error when the image URL cannot be read and the file is missing', async () => {
+  const api = createApi()
+  api.exists.mockResolvedValue(false)
+  api.getUrl.mockResolvedValue('')
+
+  const instance = await createInstanceWithApi(context, api)
+
+  expect(instance.render().some((node) => node.text === 'Image could not be found')).toBe(true)
+})
+
+test('falls back to a load error when checking whether the image exists fails', async () => {
+  const api = createApi()
+  api.exists.mockRejectedValue(new Error('filesystem unavailable'))
   api.getUrl.mockResolvedValue('')
 
   const instance = await createInstanceWithApi(context, api)
@@ -80,6 +102,7 @@ test('uses defaults when the view context is missing', async () => {
   expect(api.setSavedState).toHaveBeenCalledWith(0, undefined)
   expect(api.getUrl).not.toHaveBeenCalled()
   expect(api.getFileSize).not.toHaveBeenCalled()
+  expect(api.exists).not.toHaveBeenCalled()
   expect(instance.render().some((node) => node.text === 'Image could not be loaded')).toBe(true)
 })
 
@@ -100,9 +123,20 @@ test('forwards pointer and image events to the media preview api', async () => {
   instance.handleMediaPreviewWheel(70, 0)
   expect(api.handleWheel).toHaveBeenCalledWith(7, 0, 0, 0, 70)
 
-  instance.handleMediaPreviewImageError()
+  await instance.handleMediaPreviewImageError()
   expect(api.handleError).toHaveBeenCalledWith(7)
+  expect(api.exists).toHaveBeenCalledWith('/workspace/image.png')
   expect(instance.render().some((node) => node.text === 'Image could not be loaded')).toBe(true)
+})
+
+test('renders a not found error when the image disappears before the error event', async () => {
+  const api = createApi()
+  const instance = await createInstanceWithApi(context, api)
+  api.exists.mockResolvedValue(false)
+
+  await instance.handleMediaPreviewImageError()
+
+  expect(instance.render().some((node) => node.text === 'Image could not be found')).toBe(true)
 })
 
 test('renders image dimensions and file size as status bar items', async () => {
@@ -215,7 +249,7 @@ test('forwards legacy view events and normalizes invalid coordinates', async () 
   const api = createApi()
   const instance = await createInstanceWithApi(context, api)
 
-  instance.handleEvent?.({ type: 'error' })
+  await instance.handleEvent?.({ type: 'error' })
   expect(api.handleError).toHaveBeenCalledWith(7)
 
   instance.handleEvent?.({ name: 'pointerdown', type: 'contextmenu', x: Infinity, y: 20 })

--- a/packages/extension/test/RenderMediaPreview.test.ts
+++ b/packages/extension/test/RenderMediaPreview.test.ts
@@ -5,6 +5,7 @@ import { render } from '../src/parts/RenderMediaPreview/RenderMediaPreview.ts'
 const state = {
   domMatrixString: 'matrix(1, 0, 0, 1, 10, 20)',
   error: false,
+  errorMessage: '',
   fileSize: 873,
   height: 1,
   pointerDown: false,
@@ -52,6 +53,7 @@ test('renders an error without an image', () => {
   const dom = render({
     ...state,
     error: true,
+    errorMessage: 'Image could not be found',
   })
 
   expect(dom).toEqual([
@@ -73,7 +75,7 @@ test('renders an error without an image', () => {
     },
     {
       childCount: 0,
-      text: 'Image could not be loaded',
+      text: 'Image could not be found',
       type: VirtualDomElements.Text,
     },
   ])

--- a/packages/extension/test/RenderStatusBarItems.test.ts
+++ b/packages/extension/test/RenderStatusBarItems.test.ts
@@ -6,6 +6,7 @@ test('renders image metadata as two status bar items', () => {
     renderStatusBarItems({
       domMatrixString: '',
       error: false,
+      errorMessage: '',
       fileSize: 873,
       height: 480,
       pointerDown: false,


### PR DESCRIPTION
Missing media files now show an explicit "Image could not be found" message after the preview error event checks the source URI. Existing but invalid images keep the current load-error message, with regression coverage for both cases.