### PR TITLE
feature: update eslint config

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "packages/*"
       ],
       "devDependencies": {
-        "@lvce-editor/eslint-config": "^18.2.0",
+        "@lvce-editor/eslint-config": "^18.4.0",
         "@types/node": "^26.1.2",
         "eslint": "^10.8.0",
         "jest": "^30.4.2",
@@ -2927,9 +2927,9 @@
       }
     },
     "node_modules/@lvce-editor/eslint-config": {
-      "version": "18.2.0",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/eslint-config/-/eslint-config-18.2.0.tgz",
-      "integrity": "sha512-depjU3Z65NieU9IHl3xNUZIrP1Xt1AwQf6n9CEQxefGFttsx6XoW/CQ2BaBRD5ROTsYiSVXM9kaJF4g24TuX2Q==",
+      "version": "18.4.0",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/eslint-config/-/eslint-config-18.4.0.tgz",
+      "integrity": "sha512-Hni5Ub2jqyAQ3FgsGS3gk6PT/jKF5mS6oFZrqgDjJTcBf5nlZGg8WjEwpcyVUagVcrQPqrcJprEbImVvFUohFQ==",
       "dev": true,
       "license": "MIT",
       "workspaces": [
@@ -2941,16 +2941,16 @@
         "@eslint/js": "10.0.1",
         "@eslint/json": "2.0.1",
         "@eslint/markdown": "8.0.3",
-        "@lvce-editor/eslint-plugin-devcontainer": "18.2.0",
-        "@lvce-editor/eslint-plugin-e2e": "18.2.0",
-        "@lvce-editor/eslint-plugin-eslint-config": "18.2.0",
-        "@lvce-editor/eslint-plugin-extension-json": "18.2.0",
-        "@lvce-editor/eslint-plugin-github-actions": "18.2.0",
-        "@lvce-editor/eslint-plugin-nvmrc": "18.2.0",
-        "@lvce-editor/eslint-plugin-regex": "18.2.0",
-        "@lvce-editor/eslint-plugin-rpc": "18.2.0",
-        "@lvce-editor/eslint-plugin-tsconfig": "18.2.0",
-        "@lvce-editor/eslint-plugin-virtual-dom": "18.2.0",
+        "@lvce-editor/eslint-plugin-devcontainer": "18.4.0",
+        "@lvce-editor/eslint-plugin-e2e": "18.4.0",
+        "@lvce-editor/eslint-plugin-eslint-config": "18.4.0",
+        "@lvce-editor/eslint-plugin-extension-json": "18.4.0",
+        "@lvce-editor/eslint-plugin-github-actions": "18.4.0",
+        "@lvce-editor/eslint-plugin-nvmrc": "18.4.0",
+        "@lvce-editor/eslint-plugin-regex": "18.4.0",
+        "@lvce-editor/eslint-plugin-rpc": "18.4.0",
+        "@lvce-editor/eslint-plugin-tsconfig": "18.4.0",
+        "@lvce-editor/eslint-plugin-virtual-dom": "18.4.0",
         "eslint-plugin-jest": "29.15.4",
         "eslint-plugin-n": "18.2.1",
         "eslint-plugin-package-json": "1.5.0",
@@ -2965,9 +2965,9 @@
       }
     },
     "node_modules/@lvce-editor/eslint-plugin-devcontainer": {
-      "version": "18.2.0",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/eslint-plugin-devcontainer/-/eslint-plugin-devcontainer-18.2.0.tgz",
-      "integrity": "sha512-oGP5M6eRRNsxBNdeEWJHdB2lUU7MBlUKkSO9laZhdw8sz52cCTldh75IN3+Xj/WUN7tkHgN+RybfxjhfLzOg9g==",
+      "version": "18.4.0",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/eslint-plugin-devcontainer/-/eslint-plugin-devcontainer-18.4.0.tgz",
+      "integrity": "sha512-+iItlCPV5Xj3c0q5iCZZR9nZeiFYNw/InwMYEj2CfHDi4XmJ+TSInMFyQSK6+GDMezD1okly7CDHyzM2YCpE9g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2975,23 +2975,23 @@
       }
     },
     "node_modules/@lvce-editor/eslint-plugin-e2e": {
-      "version": "18.2.0",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/eslint-plugin-e2e/-/eslint-plugin-e2e-18.2.0.tgz",
-      "integrity": "sha512-AIpv+tOAMqH+rBK/Mx7P7pzKpF3YnS3xCZJBoHxx4VdWBSMrhTNQJvkXdhIZIgu9uGKU6FbBTq+o9FBk1jTfhw==",
+      "version": "18.4.0",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/eslint-plugin-e2e/-/eslint-plugin-e2e-18.4.0.tgz",
+      "integrity": "sha512-lg75DLSSrn9vt2p1OGkettK5CEOOZU+26hBEIaU1HKv5q8PgaM+jIhPF/g4KutMgq0F0qjXcika4tlPbQBFRGw==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@lvce-editor/eslint-plugin-eslint-config": {
-      "version": "18.2.0",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/eslint-plugin-eslint-config/-/eslint-plugin-eslint-config-18.2.0.tgz",
-      "integrity": "sha512-yVwr5EunNy7lh4sCaeu6y0/jYpMTqgP/S7lZOMz4OUn26skMxF+weRFjIKiADvx2FC65YkrWDx7eC0fRtk3AEA==",
+      "version": "18.4.0",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/eslint-plugin-eslint-config/-/eslint-plugin-eslint-config-18.4.0.tgz",
+      "integrity": "sha512-BW+7W4Gecp2CenHuVy5VRggIHjJ6vVhkJpL59XYRIf5TqFznEhVDW6iIipePL2kGtu/JnXh6162QE3rEpsJ7qg==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@lvce-editor/eslint-plugin-extension-json": {
-      "version": "18.2.0",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/eslint-plugin-extension-json/-/eslint-plugin-extension-json-18.2.0.tgz",
-      "integrity": "sha512-Z6A3jwLDvUsDaP2AMZ80QCr7xGVCsJY5MPj4K5hMR6BeXm2nBqv4bp+NFFFFh9fcvzhh3Lf1Uq+r/uwAsL8p5A==",
+      "version": "18.4.0",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/eslint-plugin-extension-json/-/eslint-plugin-extension-json-18.4.0.tgz",
+      "integrity": "sha512-jd86DG62e/DLvMWMh03byuBj/k9kOeWXRUSSuGTb9be0TsjKdKbeP8hDUFBrLD8osaNUMr5tfDsNZE19gDjA2Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2999,9 +2999,9 @@
       }
     },
     "node_modules/@lvce-editor/eslint-plugin-github-actions": {
-      "version": "18.2.0",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/eslint-plugin-github-actions/-/eslint-plugin-github-actions-18.2.0.tgz",
-      "integrity": "sha512-jzC9qzB6wl7lQREaiW1EWWIp8G+eOF6M71R3Xj6qGAbGhAbDvb/MOEHQsLZW/DBUTtDyskC7LU9UvxmxPE2H1g==",
+      "version": "18.4.0",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/eslint-plugin-github-actions/-/eslint-plugin-github-actions-18.4.0.tgz",
+      "integrity": "sha512-HAkU0VXCXqiRSpKdGxjkHDBrV7w38uVtF4iOwpELffx6Olt97aJLz5/6nTZvJShv+BcdEgnvH1nnog0FN79tlQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3010,9 +3010,9 @@
       }
     },
     "node_modules/@lvce-editor/eslint-plugin-nvmrc": {
-      "version": "18.2.0",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/eslint-plugin-nvmrc/-/eslint-plugin-nvmrc-18.2.0.tgz",
-      "integrity": "sha512-fybjUNLG3Jk+4dHn9Jyj94EzFMN8f1HP0avE2o8IIGFbR5B3lBw49Hz9aRQEZMy8l4vbk3OtKC9h3q6t1sQ38w==",
+      "version": "18.4.0",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/eslint-plugin-nvmrc/-/eslint-plugin-nvmrc-18.4.0.tgz",
+      "integrity": "sha512-wiv8PY1qn95Sxhy2PoplK9ZplEtjqSQWEzTWfWg3OkR5Kay8w1zf3JiTX86mhT4ic6BQ+A7d5hxgJ+T6H5EKuA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3020,23 +3020,23 @@
       }
     },
     "node_modules/@lvce-editor/eslint-plugin-regex": {
-      "version": "18.2.0",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/eslint-plugin-regex/-/eslint-plugin-regex-18.2.0.tgz",
-      "integrity": "sha512-Cm++lkCreG53R73iocNfXLOa/uVLjKRDugQBWV4sy2XVgyZvsZWeCKZWBfMsN+LP3MRVj2p0Fzlbi5ywHI47YQ==",
+      "version": "18.4.0",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/eslint-plugin-regex/-/eslint-plugin-regex-18.4.0.tgz",
+      "integrity": "sha512-7A6AiK56pWt6s3eYkdC2heynXfKGAfOGsi7/xgT/Pvb91SJN5VheIl3WMGt2hcDWrsd5dUJfq5BWk7ZieSYyzw==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@lvce-editor/eslint-plugin-rpc": {
-      "version": "18.2.0",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/eslint-plugin-rpc/-/eslint-plugin-rpc-18.2.0.tgz",
-      "integrity": "sha512-mPhh+IAk7NnlcuSfFLDclypKlY0PwBjJNc3hPn2Wma24Ww3kHwlU+p1SlvU/jU5T12kBcqb60djIseBL03xBnw==",
+      "version": "18.4.0",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/eslint-plugin-rpc/-/eslint-plugin-rpc-18.4.0.tgz",
+      "integrity": "sha512-NkXd4SXwaKJHUfz0z7i+wrDXxcp9xZaPTuOs/Eyr8nMvdw7q6lU+B+wEZNuu0sM3l3uboiKhVbRIIlFN51InEg==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@lvce-editor/eslint-plugin-tsconfig": {
-      "version": "18.2.0",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/eslint-plugin-tsconfig/-/eslint-plugin-tsconfig-18.2.0.tgz",
-      "integrity": "sha512-nj9Rsrdbpdzqd4WrvGYWFCKOSALn/iqPrSHeyyQqpUf2+ZzsZxmy2pnnbCGuNozZ3BRr8AazwliygPcYflJIcw==",
+      "version": "18.4.0",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/eslint-plugin-tsconfig/-/eslint-plugin-tsconfig-18.4.0.tgz",
+      "integrity": "sha512-DgMtmiEr1t65qoObuq8vptXOx/Ucyk3aeJFoZdr9Ze8gwN0hUdFMyCZmNmVqN+tW06HJ+Drc2F1Ts8+SfCWOiA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3044,9 +3044,9 @@
       }
     },
     "node_modules/@lvce-editor/eslint-plugin-virtual-dom": {
-      "version": "18.2.0",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/eslint-plugin-virtual-dom/-/eslint-plugin-virtual-dom-18.2.0.tgz",
-      "integrity": "sha512-bFPELVF4H7uSUDS7gQ4v2naq8gfJ+aTA0upxCkVxPkbrl2j+7sZP6aTtL6Tl+i90VnEZ57sJeJUu0DXjETDt5Q==",
+      "version": "18.4.0",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/eslint-plugin-virtual-dom/-/eslint-plugin-virtual-dom-18.4.0.tgz",
+      "integrity": "sha512-DZ7gFfc06T2Ysf12vW3M6pGUzOQtxgSwdhkTasSqzvuxFKqN1vBw5koOzhPL5QjhMlLFY9u/ncMWq5CX+3s/8g==",
       "dev": true,
       "license": "MIT"
     },

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "printWidth": 130
   },
   "devDependencies": {
-    "@lvce-editor/eslint-config": "^18.2.0",
+    "@lvce-editor/eslint-config": "^18.4.0",
     "@types/node": "^26.1.2",
     "eslint": "^10.8.0",
     "jest": "^30.4.2",

--- a/packages/e2e/src/media-preview-apng-visible.ts
+++ b/packages/e2e/src/media-preview-apng-visible.ts
@@ -4,7 +4,8 @@ import type { Test } from '@lvce-editor/test-with-playwright'
 export const name = 'media-preview-apng-visible'
 
 export const test: Test = async ({ expect, Locator, Main }) => {
-  await Main.openUri(import.meta.resolve('../files/sample.apng'))
+  const uri = import.meta.resolve('../files/sample.apng')
+  await Main.openUri(uri)
 
   const image = Locator('.MediaPreviewImage')
   const error = Locator('.MediaPreviewError')

--- a/packages/e2e/src/media-preview-avif-visible.ts
+++ b/packages/e2e/src/media-preview-avif-visible.ts
@@ -3,7 +3,8 @@ import type { Test } from '@lvce-editor/test-with-playwright'
 export const name = 'media-preview-avif-visible'
 
 export const test: Test = async ({ expect, Locator, Main }) => {
-  await Main.openUri(import.meta.resolve('../files/sample.avif'))
+  const uri = import.meta.resolve('../files/sample.avif')
+  await Main.openUri(uri)
 
   const image = Locator('.MediaPreviewImage')
   const error = Locator('.MediaPreviewError')

--- a/packages/e2e/src/media-preview-bmp-visible.ts
+++ b/packages/e2e/src/media-preview-bmp-visible.ts
@@ -3,7 +3,8 @@ import type { Test } from '@lvce-editor/test-with-playwright'
 export const name = 'media-preview-bmp-visible'
 
 export const test: Test = async ({ expect, Locator, Main }) => {
-  await Main.openUri(import.meta.resolve('../files/sample.bmp'))
+  const uri = import.meta.resolve('../files/sample.bmp')
+  await Main.openUri(uri)
 
   const image = Locator('.MediaPreviewImage')
   const error = Locator('.MediaPreviewError')

--- a/packages/e2e/src/media-preview-content-containment.ts
+++ b/packages/e2e/src/media-preview-content-containment.ts
@@ -3,7 +3,8 @@ import type { Test } from '@lvce-editor/test-with-playwright'
 export const name = 'media-preview-content-containment'
 
 export const test: Test = async ({ expect, Locator, Main }) => {
-  await Main.openUri(import.meta.resolve('../files/file.png'))
+  const uri = import.meta.resolve('../files/file.png')
+  await Main.openUri(uri)
 
   const content = Locator('.MediaPreviewContent')
   await expect(content).toHaveCSS('contain', 'strict')

--- a/packages/e2e/src/media-preview-content-visible.ts
+++ b/packages/e2e/src/media-preview-content-visible.ts
@@ -3,7 +3,8 @@ import type { Test } from '@lvce-editor/test-with-playwright'
 export const name = 'media-preview-content-visible'
 
 export const test: Test = async ({ expect, Locator, Main }) => {
-  await Main.openUri(import.meta.resolve('../files/file.png'))
+  const uri = import.meta.resolve('../files/file.png')
+  await Main.openUri(uri)
 
   const content = Locator('.MediaPreviewContent')
   await expect(content).toBeVisible()

--- a/packages/e2e/src/media-preview-copy-image.ts
+++ b/packages/e2e/src/media-preview-copy-image.ts
@@ -7,16 +7,12 @@ export const test: Test = async ({ ClipBoard, Command, ContextMenu, expect, Loca
   await Main.openUri(imageUri)
 
   await ClipBoard.enableMemoryClipBoard()
-  try {
-    const image = Locator('.MediaPreviewImage')
-    await expect(image).toHaveCount(1)
-    const states = await Command.execute('Viewlet.getAllStates')
-    const mediaPreview = Object.values(states).find(({ viewId }: any) => viewId === 'builtin.media-preview') as any
-    await Command.execute('Viewlet.executeViewletCommand', mediaPreview.uid, 'handleContextMenu', 'image', 10, 10)
-    await ContextMenu.selectItem('Copy Image')
+  const image = Locator('.MediaPreviewImage')
+  await expect(image).toHaveCount(1)
+  const states = await Command.execute('Viewlet.getAllStates')
+  const mediaPreview = Object.values(states).find(({ viewId }: any) => viewId === 'builtin.media-preview') as any
+  await Command.execute('Viewlet.executeViewletCommand', mediaPreview.uid, 'handleContextMenu', 'image', 10, 10)
+  await ContextMenu.selectItem('Copy Image')
 
-    await ClipBoard.shouldHaveImage(imageUri)
-  } finally {
-    await ClipBoard.disableMemoryClipBoard()
-  }
+  await ClipBoard.shouldHaveImage(imageUri)
 }

--- a/packages/e2e/src/media-preview-copy-path.ts
+++ b/packages/e2e/src/media-preview-copy-path.ts
@@ -7,16 +7,12 @@ export const test: Test = async ({ ClipBoard, Command, ContextMenu, expect, Loca
   await Main.openUri(imageUri)
 
   await ClipBoard.enableMemoryClipBoard()
-  try {
-    const image = Locator('.MediaPreviewImage')
-    await expect(image).toHaveCount(1)
-    const states = await Command.execute('Viewlet.getAllStates')
-    const mediaPreview = Object.values(states).find(({ viewId }: any) => viewId === 'builtin.media-preview') as any
-    await Command.execute('Viewlet.executeViewletCommand', mediaPreview.uid, 'handleContextMenu', 'image', 10, 10)
-    await ContextMenu.selectItem('Copy Path')
+  const image = Locator('.MediaPreviewImage')
+  await expect(image).toHaveCount(1)
+  const states = await Command.execute('Viewlet.getAllStates')
+  const mediaPreview = Object.values(states).find(({ viewId }: any) => viewId === 'builtin.media-preview') as any
+  await Command.execute('Viewlet.executeViewletCommand', mediaPreview.uid, 'handleContextMenu', 'image', 10, 10)
+  await ContextMenu.selectItem('Copy Path')
 
-    await ClipBoard.shouldHaveText(imageUri)
-  } finally {
-    await ClipBoard.disableMemoryClipBoard()
-  }
+  await ClipBoard.shouldHaveText(imageUri)
 }

--- a/packages/e2e/src/media-preview-dom-structure.ts
+++ b/packages/e2e/src/media-preview-dom-structure.ts
@@ -3,7 +3,8 @@ import type { Test } from '@lvce-editor/test-with-playwright'
 export const name = 'media-preview-dom-structure'
 
 export const test: Test = async ({ expect, Locator, Main }) => {
-  await Main.openUri(import.meta.resolve('../files/file.png'))
+  const uri = import.meta.resolve('../files/file.png')
+  await Main.openUri(uri)
 
   const preview = Locator('.MediaPreview')
   const content = preview.locator('.MediaPreviewContent')

--- a/packages/e2e/src/media-preview-heic-image-attributes.ts
+++ b/packages/e2e/src/media-preview-heic-image-attributes.ts
@@ -3,7 +3,8 @@ import type { Test } from '@lvce-editor/test-with-playwright'
 export const name = 'media-preview-heic-image-attributes'
 
 export const test: Test = async ({ expect, Locator, Main }) => {
-  await Main.openUri(import.meta.resolve('../files/green.heic'))
+  const uri = import.meta.resolve('../files/green.heic')
+  await Main.openUri(uri)
 
   const image = Locator('.MediaPreviewImage')
   await expect(image).toHaveAttribute('alt', '')

--- a/packages/e2e/src/media-preview-heic-visible.ts
+++ b/packages/e2e/src/media-preview-heic-visible.ts
@@ -3,7 +3,8 @@ import type { Test } from '@lvce-editor/test-with-playwright'
 export const name = 'media-preview-heic-visible'
 
 export const test: Test = async ({ expect, Locator, Main }) => {
-  await Main.openUri(import.meta.resolve('../files/green.heic'))
+  const uri = import.meta.resolve('../files/green.heic')
+  await Main.openUri(uri)
 
   const image = Locator('.MediaPreviewImage')
   const error = Locator('.MediaPreviewError')

--- a/packages/e2e/src/media-preview-heif-visible.ts
+++ b/packages/e2e/src/media-preview-heif-visible.ts
@@ -3,7 +3,8 @@ import type { Test } from '@lvce-editor/test-with-playwright'
 export const name = 'media-preview-heif-visible'
 
 export const test: Test = async ({ expect, Locator, Main }) => {
-  await Main.openUri(import.meta.resolve('../files/green.heif'))
+  const uri = import.meta.resolve('../files/green.heif')
+  await Main.openUri(uri)
 
   const image = Locator('.MediaPreviewImage')
   const error = Locator('.MediaPreviewError')

--- a/packages/e2e/src/media-preview-ico-visible.ts
+++ b/packages/e2e/src/media-preview-ico-visible.ts
@@ -3,7 +3,8 @@ import type { Test } from '@lvce-editor/test-with-playwright'
 export const name = 'media-preview-ico-visible'
 
 export const test: Test = async ({ expect, Locator, Main }) => {
-  await Main.openUri(import.meta.resolve('../files/sample.ico'))
+  const uri = import.meta.resolve('../files/sample.ico')
+  await Main.openUri(uri)
 
   const image = Locator('.MediaPreviewImage')
   const error = Locator('.MediaPreviewError')

--- a/packages/e2e/src/media-preview-image-attributes.ts
+++ b/packages/e2e/src/media-preview-image-attributes.ts
@@ -3,7 +3,8 @@ import type { Test } from '@lvce-editor/test-with-playwright'
 export const name = 'media-preview-image-attributes'
 
 export const test: Test = async ({ expect, Locator, Main }) => {
-  await Main.openUri(import.meta.resolve('../files/file.png'))
+  const uri = import.meta.resolve('../files/file.png')
+  await Main.openUri(uri)
 
   const image = Locator('.MediaPreviewImage')
   await expect(image).toHaveAttribute('alt', '')

--- a/packages/e2e/src/media-preview-image-fit.ts
+++ b/packages/e2e/src/media-preview-image-fit.ts
@@ -3,7 +3,8 @@ import type { Test } from '@lvce-editor/test-with-playwright'
 export const name = 'media-preview-image-fit'
 
 export const test: Test = async ({ expect, Locator, Main }) => {
-  await Main.openUri(import.meta.resolve('../files/file.png'))
+  const uri = import.meta.resolve('../files/file.png')
+  await Main.openUri(uri)
 
   const image = Locator('.MediaPreviewImage')
   await expect(image).toHaveCSS('max-width', '100%')

--- a/packages/e2e/src/media-preview-image-wrapper-visible.ts
+++ b/packages/e2e/src/media-preview-image-wrapper-visible.ts
@@ -3,7 +3,8 @@ import type { Test } from '@lvce-editor/test-with-playwright'
 export const name = 'media-preview-image-wrapper-visible'
 
 export const test: Test = async ({ expect, Locator, Main }) => {
-  await Main.openUri(import.meta.resolve('../files/file.png'))
+  const uri = import.meta.resolve('../files/file.png')
+  await Main.openUri(uri)
 
   const wrapper = Locator('.MediaPreviewImageWrapper')
   await expect(wrapper).toBeVisible()

--- a/packages/e2e/src/media-preview-jfif-visible.ts
+++ b/packages/e2e/src/media-preview-jfif-visible.ts
@@ -4,7 +4,8 @@ import type { Test } from '@lvce-editor/test-with-playwright'
 export const name = 'media-preview-jfif-visible'
 
 export const test: Test = async ({ expect, Locator, Main }) => {
-  await Main.openUri(import.meta.resolve('../files/sample.jfif'))
+  const uri = import.meta.resolve('../files/sample.jfif')
+  await Main.openUri(uri)
 
   const image = Locator('.MediaPreviewImage')
   const error = Locator('.MediaPreviewError')

--- a/packages/e2e/src/media-preview-jpe-visible.ts
+++ b/packages/e2e/src/media-preview-jpe-visible.ts
@@ -3,7 +3,8 @@ import type { Test } from '@lvce-editor/test-with-playwright'
 export const name = 'media-preview-jpe-visible'
 
 export const test: Test = async ({ expect, Locator, Main }) => {
-  await Main.openUri(import.meta.resolve('../files/sample.jpe'))
+  const uri = import.meta.resolve('../files/sample.jpe')
+  await Main.openUri(uri)
 
   const image = Locator('.MediaPreviewImage')
   const error = Locator('.MediaPreviewError')

--- a/packages/e2e/src/media-preview-jpeg-visible.ts
+++ b/packages/e2e/src/media-preview-jpeg-visible.ts
@@ -3,7 +3,8 @@ import type { Test } from '@lvce-editor/test-with-playwright'
 export const name = 'media-preview-jpeg-visible'
 
 export const test: Test = async ({ expect, Locator, Main }) => {
-  await Main.openUri(import.meta.resolve('../files/sample.jpeg'))
+  const uri = import.meta.resolve('../files/sample.jpeg')
+  await Main.openUri(uri)
 
   const image = Locator('.MediaPreviewImage')
   const error = Locator('.MediaPreviewError')

--- a/packages/e2e/src/media-preview-jpg-image-attributes.ts
+++ b/packages/e2e/src/media-preview-jpg-image-attributes.ts
@@ -3,7 +3,8 @@ import type { Test } from '@lvce-editor/test-with-playwright'
 export const name = 'media-preview-jpg-image-attributes'
 
 export const test: Test = async ({ expect, Locator, Main }) => {
-  await Main.openUri(import.meta.resolve('../files/sample.jpg'))
+  const uri = import.meta.resolve('../files/sample.jpg')
+  await Main.openUri(uri)
 
   const image = Locator('.MediaPreviewImage')
   await expect(image).toHaveAttribute('alt', '')

--- a/packages/e2e/src/media-preview-jpg-no-error.ts
+++ b/packages/e2e/src/media-preview-jpg-no-error.ts
@@ -3,7 +3,8 @@ import type { Test } from '@lvce-editor/test-with-playwright'
 export const name = 'media-preview-jpg-no-error'
 
 export const test: Test = async ({ expect, Locator, Main }) => {
-  await Main.openUri(import.meta.resolve('../files/sample.jpg'))
+  const uri = import.meta.resolve('../files/sample.jpg')
+  await Main.openUri(uri)
 
   const error = Locator('.MediaPreviewError')
   await expect(error).toHaveCount(0)

--- a/packages/e2e/src/media-preview-jpg-visible.ts
+++ b/packages/e2e/src/media-preview-jpg-visible.ts
@@ -3,7 +3,8 @@ import type { Test } from '@lvce-editor/test-with-playwright'
 export const name = 'media-preview-jpg-visible'
 
 export const test: Test = async ({ expect, Locator, Main }) => {
-  await Main.openUri(import.meta.resolve('../files/sample.jpg'))
+  const uri = import.meta.resolve('../files/sample.jpg')
+  await Main.openUri(uri)
 
   const image = Locator('.MediaPreviewImage')
   await expect(image).toBeVisible()

--- a/packages/e2e/src/media-preview-layout.ts
+++ b/packages/e2e/src/media-preview-layout.ts
@@ -3,7 +3,8 @@ import type { Test } from '@lvce-editor/test-with-playwright'
 export const name = 'media-preview-layout'
 
 export const test: Test = async ({ expect, Locator, Main }) => {
-  await Main.openUri(import.meta.resolve('../files/file.png'))
+  const uri = import.meta.resolve('../files/file.png')
+  await Main.openUri(uri)
 
   const preview = Locator('.MediaPreview')
   const content = Locator('.MediaPreviewContent')

--- a/packages/e2e/src/media-preview-non-primary-pointer-does-not-drag.ts
+++ b/packages/e2e/src/media-preview-non-primary-pointer-does-not-drag.ts
@@ -3,7 +3,8 @@ import type { Test } from '@lvce-editor/test-with-playwright'
 export const name = 'media-preview-non-primary-pointer-does-not-drag'
 
 export const test: Test = async ({ expect, Locator, Main }) => {
-  await Main.openUri(import.meta.resolve('../files/file.png'))
+  const uri = import.meta.resolve('../files/file.png')
+  await Main.openUri(uri)
 
   const preview = Locator('.MediaPreview')
   await preview.dispatchEvent('pointerdown', {

--- a/packages/e2e/src/media-preview-png-no-error.ts
+++ b/packages/e2e/src/media-preview-png-no-error.ts
@@ -3,7 +3,8 @@ import type { Test } from '@lvce-editor/test-with-playwright'
 export const name = 'media-preview-png-no-error'
 
 export const test: Test = async ({ expect, Locator, Main }) => {
-  await Main.openUri(import.meta.resolve('../files/file.png'))
+  const uri = import.meta.resolve('../files/file.png')
+  await Main.openUri(uri)
 
   const error = Locator('.MediaPreviewError')
   await expect(error).toHaveCount(0)

--- a/packages/e2e/src/media-preview-png-visible.ts
+++ b/packages/e2e/src/media-preview-png-visible.ts
@@ -3,7 +3,8 @@ import type { Test } from '@lvce-editor/test-with-playwright'
 export const name = 'media-preview-png-visible'
 
 export const test: Test = async ({ expect, Locator, Main }) => {
-  await Main.openUri(import.meta.resolve('../files/file.png'))
+  const uri = import.meta.resolve('../files/file.png')
+  await Main.openUri(uri)
 
   const image = Locator('.MediaPreviewImage')
   await expect(image).toBeVisible()

--- a/packages/e2e/src/media-preview-root-containment.ts
+++ b/packages/e2e/src/media-preview-root-containment.ts
@@ -3,7 +3,8 @@ import type { Test } from '@lvce-editor/test-with-playwright'
 export const name = 'media-preview-root-containment'
 
 export const test: Test = async ({ expect, Locator, Main }) => {
-  await Main.openUri(import.meta.resolve('../files/file.png'))
+  const uri = import.meta.resolve('../files/file.png')
+  await Main.openUri(uri)
 
   const preview = Locator('.MediaPreview')
   await expect(preview).toHaveCSS('contain', 'strict')

--- a/packages/e2e/src/media-preview-root-visible.ts
+++ b/packages/e2e/src/media-preview-root-visible.ts
@@ -3,7 +3,8 @@ import type { Test } from '@lvce-editor/test-with-playwright'
 export const name = 'media-preview-root-visible'
 
 export const test: Test = async ({ expect, Locator, Main }) => {
-  await Main.openUri(import.meta.resolve('../files/file.png'))
+  const uri = import.meta.resolve('../files/file.png')
+  await Main.openUri(uri)
 
   const preview = Locator('.MediaPreview')
   await expect(preview).toBeVisible()

--- a/packages/e2e/src/media-preview-status-bar-items.ts
+++ b/packages/e2e/src/media-preview-status-bar-items.ts
@@ -7,7 +7,8 @@ export const skip = true
 
 export const test: Test = async ({ expect, Locator, Main, Settings }) => {
   await Settings.update({ 'statusBar.itemsVisible': true })
-  await Main.openUri(import.meta.resolve('../files/file.png'))
+  const uri = import.meta.resolve('../files/file.png')
+  await Main.openUri(uri)
 
   const dimensions = Locator('.StatusBarItem[name="media-preview-dimensions"]')
   const size = Locator('.StatusBarItem[name="media-preview-size"]')

--- a/packages/e2e/src/media-preview-tif-visible.ts
+++ b/packages/e2e/src/media-preview-tif-visible.ts
@@ -3,7 +3,8 @@ import type { Test } from '@lvce-editor/test-with-playwright'
 export const name = 'media-preview-tif-visible'
 
 export const test: Test = async ({ expect, Locator, Main }) => {
-  await Main.openUri(import.meta.resolve('../files/sample.tif'))
+  const uri = import.meta.resolve('../files/sample.tif')
+  await Main.openUri(uri)
 
   const image = Locator('.MediaPreviewImage')
   const error = Locator('.MediaPreviewError')

--- a/packages/e2e/src/media-preview-tiff-visible.ts
+++ b/packages/e2e/src/media-preview-tiff-visible.ts
@@ -3,7 +3,8 @@ import type { Test } from '@lvce-editor/test-with-playwright'
 export const name = 'media-preview-tiff-visible'
 
 export const test: Test = async ({ expect, Locator, Main }) => {
-  await Main.openUri(import.meta.resolve('../files/sample.tiff'))
+  const uri = import.meta.resolve('../files/sample.tiff')
+  await Main.openUri(uri)
 
   const image = Locator('.MediaPreviewImage')
   const error = Locator('.MediaPreviewError')

--- a/packages/e2e/src/media-preview-uppercase-heic-no-error.ts
+++ b/packages/e2e/src/media-preview-uppercase-heic-no-error.ts
@@ -3,7 +3,8 @@ import type { Test } from '@lvce-editor/test-with-playwright'
 export const name = 'media-preview-uppercase-heic-no-error'
 
 export const test: Test = async ({ expect, Locator, Main }) => {
-  await Main.openUri(import.meta.resolve('../files/green.HEIC'))
+  const uri = import.meta.resolve('../files/green.HEIC')
+  await Main.openUri(uri)
 
   const error = Locator('.MediaPreviewError')
   await expect(error).toHaveCount(0)

--- a/packages/e2e/src/media-preview-uppercase-heic-visible.ts
+++ b/packages/e2e/src/media-preview-uppercase-heic-visible.ts
@@ -3,7 +3,8 @@ import type { Test } from '@lvce-editor/test-with-playwright'
 export const name = 'media-preview-uppercase-heic-visible'
 
 export const test: Test = async ({ expect, Locator, Main }) => {
-  await Main.openUri(import.meta.resolve('../files/green.HEIC'))
+  const uri = import.meta.resolve('../files/green.HEIC')
+  await Main.openUri(uri)
 
   const image = Locator('.MediaPreviewImage')
   const error = Locator('.MediaPreviewError')

--- a/packages/e2e/src/media-preview-valid-gif-visible.ts
+++ b/packages/e2e/src/media-preview-valid-gif-visible.ts
@@ -3,7 +3,8 @@ import type { Test } from '@lvce-editor/test-with-playwright'
 export const name = 'media-preview-valid-gif-visible'
 
 export const test: Test = async ({ expect, Locator, Main }) => {
-  await Main.openUri(import.meta.resolve('../files/sample.gif'))
+  const uri = import.meta.resolve('../files/sample.gif')
+  await Main.openUri(uri)
 
   const image = Locator('.MediaPreviewImage')
   const error = Locator('.MediaPreviewError')

--- a/packages/e2e/src/media-preview-webp-image-attributes.ts
+++ b/packages/e2e/src/media-preview-webp-image-attributes.ts
@@ -3,7 +3,8 @@ import type { Test } from '@lvce-editor/test-with-playwright'
 export const name = 'media-preview-webp-image-attributes'
 
 export const test: Test = async ({ expect, Locator, Main }) => {
-  await Main.openUri(import.meta.resolve('../files/sample.webp'))
+  const uri = import.meta.resolve('../files/sample.webp')
+  await Main.openUri(uri)
 
   const image = Locator('.MediaPreviewImage')
   await expect(image).toHaveAttribute('alt', '')

--- a/packages/e2e/src/media-preview-webp-no-error.ts
+++ b/packages/e2e/src/media-preview-webp-no-error.ts
@@ -3,7 +3,8 @@ import type { Test } from '@lvce-editor/test-with-playwright'
 export const name = 'media-preview-webp-no-error'
 
 export const test: Test = async ({ expect, Locator, Main }) => {
-  await Main.openUri(import.meta.resolve('../files/sample.webp'))
+  const uri = import.meta.resolve('../files/sample.webp')
+  await Main.openUri(uri)
 
   const error = Locator('.MediaPreviewError')
   await expect(error).toHaveCount(0)

--- a/packages/e2e/src/media-preview-webp-visible.ts
+++ b/packages/e2e/src/media-preview-webp-visible.ts
@@ -3,7 +3,8 @@ import type { Test } from '@lvce-editor/test-with-playwright'
 export const name = 'media-preview-webp-visible'
 
 export const test: Test = async ({ expect, Locator, Main }) => {
-  await Main.openUri(import.meta.resolve('../files/sample.webp'))
+  const uri = import.meta.resolve('../files/sample.webp')
+  await Main.openUri(uri)
 
   const image = Locator('.MediaPreviewImage')
   await expect(image).toBeVisible()

--- a/packages/e2e/src/media-preview-wrapper-containment.ts
+++ b/packages/e2e/src/media-preview-wrapper-containment.ts
@@ -3,7 +3,8 @@ import type { Test } from '@lvce-editor/test-with-playwright'
 export const name = 'media-preview-wrapper-containment'
 
 export const test: Test = async ({ expect, Locator, Main }) => {
-  await Main.openUri(import.meta.resolve('../files/file.png'))
+  const uri = import.meta.resolve('../files/file.png')
+  await Main.openUri(uri)
 
   const wrapper = Locator('.MediaPreviewImageWrapper')
   await expect(wrapper).toHaveCSS('contain', 'content')


### PR DESCRIPTION
Summary:
- update @lvce-editor/eslint-config to 18.4.0
- adapt media preview e2e tests to the new URI and clipboard rules