### PR TITLE
feature: extract media preview renderers

### DIFF
--- a/packages/extension/src/parts/RenderError/RenderError.ts
+++ b/packages/extension/src/parts/RenderError/RenderError.ts
@@ -1,0 +1,31 @@
+import { mergeClassNames, text, VirtualDomElements, type VirtualDomNode } from '@lvce-editor/virtual-dom-worker'
+import type { MediaPreviewState } from '../MediaPreviewViewInstance/MediaPreviewViewInstance.ts'
+
+const handleOpenInTextEditor = 'handleOpenInTextEditor'
+
+const errorMessageNode: VirtualDomNode = {
+  childCount: 1,
+  className: 'MediaPreviewErrorMessage',
+  type: VirtualDomElements.Span,
+}
+
+const openInTextEditorButtonNode: VirtualDomNode = {
+  childCount: 1,
+  className: mergeClassNames('Button', 'ButtonSecondary', 'MediaPreviewOpenInTextEditor'),
+  name: 'openInTextEditor',
+  onClick: handleOpenInTextEditor,
+  type: VirtualDomElements.Button,
+}
+
+export const renderError = (state: Readonly<MediaPreviewState>): readonly VirtualDomNode[] => {
+  const { canOpenAsText, errorMessage } = state
+  const errorNode: VirtualDomNode = {
+    childCount: canOpenAsText ? 2 : 1,
+    className: 'MediaPreviewError',
+    type: VirtualDomElements.Div,
+  }
+  const messageNodes = [errorMessageNode, text(errorMessage)]
+  return canOpenAsText
+    ? [errorNode, ...messageNodes, openInTextEditorButtonNode, text('Open in Text Editor')]
+    : [errorNode, ...messageNodes]
+}

--- a/packages/extension/src/parts/RenderImage/RenderImage.ts
+++ b/packages/extension/src/parts/RenderImage/RenderImage.ts
@@ -1,0 +1,38 @@
+import { VirtualDomElements, type VirtualDomNode } from '@lvce-editor/virtual-dom-worker'
+import type { MediaPreviewState } from '../MediaPreviewViewInstance/MediaPreviewViewInstance.ts'
+
+const handleMediaPreviewImageError = 'handleMediaPreviewImageError'
+const handleMediaPreviewImageLoad = 'handleMediaPreviewImageLoad'
+const handleContextMenu = 'handleContextMenu'
+
+const contentNode: VirtualDomNode = {
+  childCount: 1,
+  className: 'MediaPreviewContent',
+  type: VirtualDomElements.Div,
+}
+
+const imageWrapperNode: VirtualDomNode = {
+  childCount: 1,
+  className: 'MediaPreviewImageWrapper',
+  type: VirtualDomElements.Div,
+}
+
+export const renderImage = (state: Readonly<MediaPreviewState>): readonly VirtualDomNode[] => {
+  const { url } = state
+  return [
+    contentNode,
+    imageWrapperNode,
+    {
+      alt: '',
+      childCount: 0,
+      className: 'MediaPreviewImage',
+      draggable: false,
+      name: 'image',
+      onContextMenu: handleContextMenu,
+      onError: handleMediaPreviewImageError,
+      onLoad: handleMediaPreviewImageLoad,
+      src: url,
+      type: VirtualDomElements.Img,
+    },
+  ]
+}

--- a/packages/extension/src/parts/RenderMediaPreview/RenderMediaPreview.ts
+++ b/packages/extension/src/parts/RenderMediaPreview/RenderMediaPreview.ts
@@ -1,71 +1,10 @@
-import { mergeClassNames, text, VirtualDomElements, type VirtualDomNode } from '@lvce-editor/virtual-dom-worker'
+import { VirtualDomElements, type VirtualDomNode } from '@lvce-editor/virtual-dom-worker'
 import type { MediaPreviewState } from '../MediaPreviewViewInstance/MediaPreviewViewInstance.ts'
+import { renderError } from '../RenderError/RenderError.ts'
+import { renderImage } from '../RenderImage/RenderImage.ts'
 
-const handleMediaPreviewImageError = 'handleMediaPreviewImageError'
-const handleMediaPreviewImageLoad = 'handleMediaPreviewImageLoad'
-const handleContextMenu = 'handleContextMenu'
-const handleOpenInTextEditor = 'handleOpenInTextEditor'
 const handleMediaPreviewPointerDown = 'handleMediaPreviewPointerDown'
 const handleMediaPreviewWheel = 'handleMediaPreviewWheel'
-
-const errorMessageNode: VirtualDomNode = {
-  childCount: 1,
-  className: 'MediaPreviewErrorMessage',
-  type: VirtualDomElements.Span,
-}
-
-const openInTextEditorButtonNode: VirtualDomNode = {
-  childCount: 1,
-  className: mergeClassNames('Button', 'ButtonSecondary', 'MediaPreviewOpenInTextEditor'),
-  name: 'openInTextEditor',
-  onClick: handleOpenInTextEditor,
-  type: VirtualDomElements.Button,
-}
-
-const contentNode: VirtualDomNode = {
-  childCount: 1,
-  className: 'MediaPreviewContent',
-  type: VirtualDomElements.Div,
-}
-
-const imageWrapperNode: VirtualDomNode = {
-  childCount: 1,
-  className: 'MediaPreviewImageWrapper',
-  type: VirtualDomElements.Div,
-}
-
-const renderError = (state: Readonly<MediaPreviewState>): readonly VirtualDomNode[] => {
-  const { canOpenAsText, errorMessage } = state
-  const errorNode: VirtualDomNode = {
-    childCount: canOpenAsText ? 2 : 1,
-    className: 'MediaPreviewError',
-    type: VirtualDomElements.Div,
-  }
-  const messageNodes = [errorMessageNode, text(errorMessage)]
-  return canOpenAsText
-    ? [errorNode, ...messageNodes, openInTextEditorButtonNode, text('Open in Text Editor')]
-    : [errorNode, ...messageNodes]
-}
-
-const renderImage = (state: Readonly<MediaPreviewState>): readonly VirtualDomNode[] => {
-  const { url } = state
-  return [
-    contentNode,
-    imageWrapperNode,
-    {
-      alt: '',
-      childCount: 0,
-      className: 'MediaPreviewImage',
-      draggable: false,
-      name: 'image',
-      onContextMenu: handleContextMenu,
-      onError: handleMediaPreviewImageError,
-      onLoad: handleMediaPreviewImageLoad,
-      src: url,
-      type: VirtualDomElements.Img,
-    },
-  ]
-}
 
 export const render = (state: Readonly<MediaPreviewState>): readonly VirtualDomNode[] => {
   const { error, pointerDown } = state


### PR DESCRIPTION
Extract the image and error rendering branches into dedicated modules while preserving the media preview output.