### PR TITLE
fix: name media preview worker

### DIFF
--- a/packages/extension/extension.json
+++ b/packages/extension/extension.json
@@ -6,7 +6,7 @@
   "browser": "dist/mediaPreviewMain.js",
   "contentSecurityPolicy": ["default-src 'none'", "script-src 'self'"],
   "isolated": true,
-  "workerName": "Media Preview Extension Worker",
+  "workerName": "Media Preview Worker",
   "activation": ["onView:builtin.media-preview"],
   "languages": [],
   "rpc": [

--- a/packages/extension/test/ExtensionManifest.test.ts
+++ b/packages/extension/test/ExtensionManifest.test.ts
@@ -1,0 +1,13 @@
+import { expect, test } from '@jest/globals'
+import { readFileSync } from 'node:fs'
+
+interface ExtensionManifest {
+  readonly workerName: string
+}
+
+const manifestUrl = new URL('../extension.json', import.meta.url)
+const manifest = JSON.parse(readFileSync(manifestUrl, 'utf8')) as ExtensionManifest
+
+test('uses the media preview worker name', () => {
+  expect(manifest.workerName).toBe('Media Preview Worker')
+})


### PR DESCRIPTION
Rename the extension worker displayed in developer tools to Media Preview Worker and cover the manifest value with a regression test.