### PR TITLE
fix: report media preview image dimensions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3051,9 +3051,9 @@
       "license": "MIT"
     },
     "node_modules/@lvce-editor/extension-host-helper-process": {
-      "version": "0.99.25",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/extension-host-helper-process/-/extension-host-helper-process-0.99.25.tgz",
-      "integrity": "sha512-uy89/o5+Kk1ROBcpA5acNiMInxLr5HK7YMUqujV3X15l2PFqDApNrlMsP2aSjeHtXZh92PfW5VCjd11wZD7aEQ==",
+      "version": "0.100.3",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/extension-host-helper-process/-/extension-host-helper-process-0.100.3.tgz",
+      "integrity": "sha512-AzCbzrWkzWzs83tktFOoZbzVtuwJfDNpeZfCIdfIJ86rjRTIAxVDxO8HZnd7Yh9HecN+NZoC7JS8kpl4H/Rr2w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3407,9 +3407,9 @@
       }
     },
     "node_modules/@lvce-editor/ripgrep": {
-      "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/ripgrep/-/ripgrep-5.5.0.tgz",
-      "integrity": "sha512-k4VM7TG6/dENvTqiuJJZtSr4x9ZCzCnRsUVZFijVexPSvR0JmHY6MC1gAcLeb13kQbtL/CVJZNJ/sk64JSMSeg==",
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/ripgrep/-/ripgrep-5.6.0.tgz",
+      "integrity": "sha512-ti5b+5vhvmpcbrMhq8kuN8Ek9DVADzT+umjt4/KMkiqgMZf98D7pzfu4rnDliFRNUJLIMAM2+eDvSNXX/yi5UA==",
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -3467,14 +3467,14 @@
       }
     },
     "node_modules/@lvce-editor/server": {
-      "version": "0.99.25",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/server/-/server-0.99.25.tgz",
-      "integrity": "sha512-6OtHR3JtKn4IP7IzkDAgJAQqjdMA6PqQlavGzVgRp7qK91s0hM3JM8CLrQK/GFBdQhB87zgfA5/RQszc0cMPVQ==",
+      "version": "0.100.3",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/server/-/server-0.100.3.tgz",
+      "integrity": "sha512-S2U82benzMvl1k1zXk//Y6yOEvhYQDFHa5I3zltADMG6AVb7XlZJsMFoccaJkJnIBmsVdVmwpk/5AC9xcFsdSQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@lvce-editor/shared-process": "0.99.25",
-        "@lvce-editor/static-server": "0.99.25"
+        "@lvce-editor/shared-process": "0.100.3",
+        "@lvce-editor/static-server": "0.100.3"
       },
       "bin": {
         "server": "bin/server.js"
@@ -3484,14 +3484,14 @@
       }
     },
     "node_modules/@lvce-editor/shared-process": {
-      "version": "0.99.25",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/shared-process/-/shared-process-0.99.25.tgz",
-      "integrity": "sha512-tnlWjW53GJxR6Tqp57A/rgWYbY7E9Acy384qvFIsrW3ToX1JX/Acp9gwH4m6kSOvGnV6t+DEvgV+9ZPbupy0Bg==",
+      "version": "0.100.3",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/shared-process/-/shared-process-0.100.3.tgz",
+      "integrity": "sha512-aNmMKkV+V3gvPz0U7hzyNNWuWYnB/MCJOaPk65cgjNafQnvc0uxmQMx1++v0JMvUsybroTKwvc4oQaUWf+13CA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@lvce-editor/assert": "1.9.0",
-        "@lvce-editor/extension-host-helper-process": "0.99.25",
+        "@lvce-editor/extension-host-helper-process": "0.100.3",
         "@lvce-editor/ipc": "16.10.0",
         "@lvce-editor/json-rpc": "8.6.0",
         "@lvce-editor/jsonc-parser": "1.5.0",
@@ -3523,9 +3523,9 @@
       }
     },
     "node_modules/@lvce-editor/static-server": {
-      "version": "0.99.25",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/static-server/-/static-server-0.99.25.tgz",
-      "integrity": "sha512-b2nKVXkDvwM0HeJcebQfTW5dVKfWgRezZG1wlI7e/nuyqy2Acin1GVYZf3XZXTOoRxipkqkFOM6ibhTM+oFhOw==",
+      "version": "0.100.3",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/static-server/-/static-server-0.100.3.tgz",
+      "integrity": "sha512-C3pMTwHvtPIbV3T856euh7Gq4PGgz89t09N9xfwkiZJqp5CGWhTtMeIgZIPAse2730TZIzJgLPRM9KVcp18kjw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -3533,14 +3533,14 @@
       }
     },
     "node_modules/@lvce-editor/test-with-playwright": {
-      "version": "22.21.0",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/test-with-playwright/-/test-with-playwright-22.21.0.tgz",
-      "integrity": "sha512-fENK3H3VjlQMZvzgn0KshUiaLkPes7RWlmc3UMxPwx+znqQLdJ6xHDjgGT7Wkbi83FJLz/JDDJVjEOaQdeBngA==",
+      "version": "22.22.0",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/test-with-playwright/-/test-with-playwright-22.22.0.tgz",
+      "integrity": "sha512-BcY0k7p/6OeCdxnVTb7AeQ17uZ3Me0+xyo8oTPwg0ZF+7cmY44ve6D8DwAvx6SmHGjrROuzoi3ebEPLn8ekdyw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@lvce-editor/test-with-playwright-worker": "22.21.0",
-        "@lvce-editor/test-worker": "^17.12.0"
+        "@lvce-editor/test-with-playwright-worker": "22.22.0",
+        "@lvce-editor/test-worker": "^17.12.1"
       },
       "bin": {
         "test-with-playwright": "bin/test-with-playwright.js"
@@ -3550,9 +3550,9 @@
       }
     },
     "node_modules/@lvce-editor/test-with-playwright-worker": {
-      "version": "22.21.0",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/test-with-playwright-worker/-/test-with-playwright-worker-22.21.0.tgz",
-      "integrity": "sha512-k6IiWHduJdSM7m1hSuqLapTodjVeuLvluXo7xhrVXP9Ep8r6BiC56nEreBLgI/SutIzK/x3FB25gVG6gYwe3jA==",
+      "version": "22.22.0",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/test-with-playwright-worker/-/test-with-playwright-worker-22.22.0.tgz",
+      "integrity": "sha512-UrcW97pG/I9+bkm7c+McOu9MbJ1Lza//xGbX8Tks/w1vISW3hc3qGyhTau/Eo0CGfUIfd4ppWysIzwglpRx1/w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -15575,7 +15575,7 @@
       "license": "MIT",
       "devDependencies": {
         "@lvce-editor/package-extension": "^3.7.0",
-        "@lvce-editor/server": "^0.99.14",
+        "@lvce-editor/server": "^0.100.3",
         "esbuild": "^0.28.1"
       }
     },
@@ -15583,7 +15583,7 @@
       "version": "0.0.0-dev",
       "license": "MIT",
       "devDependencies": {
-        "@lvce-editor/test-with-playwright": "^22.21.0"
+        "@lvce-editor/test-with-playwright": "^22.22.0"
       }
     },
     "packages/extension": {

--- a/packages/build/package.json
+++ b/packages/build/package.json
@@ -10,7 +10,7 @@
   "license": "MIT",
   "devDependencies": {
     "@lvce-editor/package-extension": "^3.7.0",
-    "@lvce-editor/server": "^0.99.14",
+    "@lvce-editor/server": "^0.100.3",
     "esbuild": "^0.28.1"
   }
 }

--- a/packages/e2e/package.json
+++ b/packages/e2e/package.json
@@ -9,6 +9,6 @@
     "e2e:headless": "node ../../node_modules/@lvce-editor/test-with-playwright/bin/test-with-playwright.js  --only-extension=../../dist --test-path=. --headless"
   },
   "devDependencies": {
-    "@lvce-editor/test-with-playwright": "^22.21.0"
+    "@lvce-editor/test-with-playwright": "^22.22.0"
   }
 }

--- a/packages/e2e/src/media-preview-status-bar-items.ts
+++ b/packages/e2e/src/media-preview-status-bar-items.ts
@@ -21,10 +21,10 @@ export const test: Test = async ({ expect, Locator, Main, Settings }) => {
 
   const dimensions = Locator('.StatusBarItem[name="media-preview-dimensions"]')
   const size = Locator('.StatusBarItem[name="media-preview-size"]')
-  await expect(dimensions).toBeVisible()
+  await waitForExpectation(() => expect(dimensions).toBeVisible())
   await waitForExpectation(() => expect(dimensions).toHaveText('256 × 256'))
-  await expect(size).toBeVisible()
-  await expect(size).toHaveText('873 B')
+  await waitForExpectation(() => expect(size).toBeVisible())
+  await waitForExpectation(() => expect(size).toHaveText('873 B'))
 
   await Main.closeAllEditors()
   await waitForExpectation(() => expect(dimensions).toBeHidden())

--- a/packages/e2e/src/media-preview-status-bar-items.ts
+++ b/packages/e2e/src/media-preview-status-bar-items.ts
@@ -2,8 +2,17 @@ import type { Test } from '@lvce-editor/test-with-playwright'
 
 export const name = 'media-preview-status-bar-items'
 
-// The e2e editor currently starts without extension status bar items enabled.
-export const skip = true
+const waitForExpectation = async (assertion: () => Promise<void>): Promise<void> => {
+  for (let attempt = 0; attempt < 40; attempt++) {
+    try {
+      await assertion()
+      return
+    } catch {
+      await new Promise((resolve) => setTimeout(resolve, 50))
+    }
+  }
+  await assertion()
+}
 
 export const test: Test = async ({ expect, Locator, Main, Settings }) => {
   await Settings.update({ 'statusBar.itemsVisible': true })
@@ -13,11 +22,11 @@ export const test: Test = async ({ expect, Locator, Main, Settings }) => {
   const dimensions = Locator('.StatusBarItem[name="media-preview-dimensions"]')
   const size = Locator('.StatusBarItem[name="media-preview-size"]')
   await expect(dimensions).toBeVisible()
-  await expect(dimensions).toHaveText('1 × 1')
+  await waitForExpectation(() => expect(dimensions).toHaveText('256 × 256'))
   await expect(size).toBeVisible()
   await expect(size).toHaveText('873 B')
 
   await Main.closeAllEditors()
-  await expect(dimensions).toBeHidden()
-  await expect(size).toBeHidden()
+  await waitForExpectation(() => expect(dimensions).toBeHidden())
+  await waitForExpectation(() => expect(size).toBeHidden())
 }

--- a/packages/extension/extension.json
+++ b/packages/extension/extension.json
@@ -27,7 +27,7 @@
         },
         {
           "name": "handleMediaPreviewImageLoad",
-          "params": ["handleMediaPreviewImageLoad", "event.target.naturalWidth", "event.target.naturalHeight"]
+          "params": ["handleMediaPreviewImageLoad", "event.currentTarget.naturalWidth", "event.currentTarget.naturalHeight"]
         },
         {
           "name": "handleMediaPreviewPointerDown",

--- a/packages/extension/src/parts/MediaPreviewView/MediaPreviewView.ts
+++ b/packages/extension/src/parts/MediaPreviewView/MediaPreviewView.ts
@@ -14,7 +14,7 @@ export const view: View<MediaPreviewViewInstance> = {
     },
     {
       name: 'handleMediaPreviewImageLoad',
-      params: ['handleMediaPreviewImageLoad', 'event.target.naturalWidth', 'event.target.naturalHeight'],
+      params: ['handleMediaPreviewImageLoad', 'event.currentTarget.naturalWidth', 'event.currentTarget.naturalHeight'],
     },
     {
       name: 'handleOpenInTextEditor',

--- a/packages/extension/test/MediaPreviewView.test.ts
+++ b/packages/extension/test/MediaPreviewView.test.ts
@@ -5,6 +5,11 @@ test('contributes a virtual dom media preview view', () => {
   expect(view.id).toBe(viewId)
   expect(view.kind).toBe('virtualDom')
   expect(view.create).toBeDefined()
+  expect(view.eventListeners?.find((listener) => listener.name === 'handleMediaPreviewImageLoad')?.params).toEqual([
+    'handleMediaPreviewImageLoad',
+    'event.currentTarget.naturalWidth',
+    'event.currentTarget.naturalHeight',
+  ])
   expect(view.eventListeners?.map((listener) => listener.name)).toEqual([
     'handleMediaPreviewImageError',
     'handleMediaPreviewImageLoad',


### PR DESCRIPTION
Use the loaded image element as the source of media dimensions and install the LVCE release that supports extension-provided view status items.

Enable end-to-end coverage for dimensions, file size, and automatic cleanup when the editor closes.