### PR TITLE
feature: cache converted HEIC previews

### DIFF
--- a/packages/extension/extension.json
+++ b/packages/extension/extension.json
@@ -7,6 +7,13 @@
   "contentSecurityPolicy": ["default-src 'none'", "script-src 'self'"],
   "isolated": true,
   "workerName": "Media Preview Worker",
+  "configuration": {
+    "mediaPreview.cachingEnabled": {
+      "type": "boolean",
+      "default": false,
+      "description": "Cache converted HEIC and HEIF images as PNG files to make subsequent previews faster."
+    }
+  },
   "activation": ["onView:builtin.media-preview"],
   "languages": [],
   "rpc": [

--- a/packages/extension/src/parts/ConvertHeicToPngUrl/ConvertHeicToPngUrl.ts
+++ b/packages/extension/src/parts/ConvertHeicToPngUrl/ConvertHeicToPngUrl.ts
@@ -1,21 +1,110 @@
+import { getFileHash, getPreference, readFileAsBlob } from '@lvce-editor/api'
 import * as ImageConversionWorker from '../ImageConversionWorker/ImageConversionWorker.ts'
 
 type ConvertHeicToPng = (heic: Blob) => Promise<Blob>
 type CreateObjectUrl = (blob: Blob) => string
+type GetFileHash = (uri: string) => Promise<string>
+type GetPreference = (key: string) => Promise<unknown>
+type ReadFileAsBlob = (uri: string) => Promise<Blob>
+
+interface ConvertHeicToPngUrlDependencies {
+  readonly cacheStorage: Readonly<CacheStorage> | undefined
+  readonly convert: ConvertHeicToPng
+  readonly createUrl: CreateObjectUrl
+  readonly getHash: GetFileHash
+  readonly getSetting: GetPreference
+  readonly readBlob: ReadFileAsBlob
+}
+
+const CacheName = 'builtin.media-preview.heic-png-v1'
+const CacheKeyPrefix = 'https://media-preview-cache.invalid/heic-png/'
+const CachingEnabledSetting = 'mediaPreview.cachingEnabled'
 
 const createObjectUrl = (blob: Blob): string => {
   return URL.createObjectURL(blob)
 }
 
+const getCache = async (cacheStorage: Readonly<CacheStorage> | undefined): Promise<Cache | undefined> => {
+  if (!cacheStorage) {
+    return undefined
+  }
+  try {
+    return await cacheStorage.open(CacheName)
+  } catch {
+    return undefined
+  }
+}
+
+const getCacheKey = (hash: string): string => {
+  return `${CacheKeyPrefix}${encodeURIComponent(hash)}.png`
+}
+
+const getCachedPng = async (cache: Readonly<Cache> | undefined, key: string): Promise<Blob | undefined> => {
+  if (!cache) {
+    return undefined
+  }
+  try {
+    const response = await cache.match(key)
+    return response?.blob()
+  } catch {
+    return undefined
+  }
+}
+
+const getFileHashForCache = async (uri: string, getHash: GetFileHash): Promise<string> => {
+  try {
+    return await getHash(uri)
+  } catch {
+    return ''
+  }
+}
+
+const putCachedPng = async (cache: Readonly<Cache> | undefined, key: string, png: Blob): Promise<void> => {
+  if (!cache) {
+    return
+  }
+  try {
+    await cache.put(key, new Response(png))
+  } catch {
+    // Caching is best-effort; the converted image can still be displayed.
+  }
+}
+
 export const convertHeicToPngUrlWithDependencies = async (
-  heic: Blob,
-  convert: ConvertHeicToPng,
-  createUrl: CreateObjectUrl,
+  uri: string,
+  dependencies: ConvertHeicToPngUrlDependencies,
 ): Promise<string> => {
+  const { cacheStorage, convert, createUrl, getHash, getSetting, readBlob } = dependencies
+  const cachingEnabled = (await getSetting(CachingEnabledSetting)) === true
+  if (!cachingEnabled) {
+    const heic = await readBlob(uri)
+    const png = await convert(heic)
+    return createUrl(png)
+  }
+
+  const hash = await getFileHashForCache(uri, getHash)
+  const cache = hash ? await getCache(cacheStorage) : undefined
+  const cacheKey = hash ? getCacheKey(hash) : ''
+  const cachedPng = cacheKey ? await getCachedPng(cache, cacheKey) : undefined
+  if (cachedPng) {
+    return createUrl(cachedPng)
+  }
+
+  const heic = await readBlob(uri)
   const png = await convert(heic)
+  if (cacheKey) {
+    await putCachedPng(cache, cacheKey, png)
+  }
   return createUrl(png)
 }
 
-export const convertHeicToPngUrl = async (heic: Blob): Promise<string> => {
-  return convertHeicToPngUrlWithDependencies(heic, ImageConversionWorker.convertHeicToPng, createObjectUrl)
+export const convertHeicToPngUrl = async (uri: string): Promise<string> => {
+  return convertHeicToPngUrlWithDependencies(uri, {
+    cacheStorage: globalThis.caches,
+    convert: ImageConversionWorker.convertHeicToPng,
+    createUrl: createObjectUrl,
+    getHash: getFileHash,
+    getSetting: getPreference,
+    readBlob: readFileAsBlob,
+  })
 }

--- a/packages/extension/src/parts/GetUrl/GetUrl.ts
+++ b/packages/extension/src/parts/GetUrl/GetUrl.ts
@@ -4,7 +4,8 @@ import { convertTiffToPngUrl } from '../ConvertTiffToPngUrl/ConvertTiffToPngUrl.
 
 type ReadAsObjectUrl = (uri: string) => Promise<ReadAsObjectUrlResult>
 type ReadFileAsBlob = (uri: string) => Promise<Blob>
-type ConvertToPngUrl = (blob: Blob) => Promise<string>
+type ConvertHeicToPngUrl = (uri: string) => Promise<string>
+type ConvertTiffToPngUrl = (blob: Blob) => Promise<string>
 
 const isHeicUri = (uri: string): boolean => {
   const normalizedUri = uri.toLowerCase()
@@ -20,13 +21,12 @@ export const getUrlWithDependencies = async (
   uri: string,
   read: ReadAsObjectUrl,
   readBlob: ReadFileAsBlob,
-  convertHeic: ConvertToPngUrl,
-  convertTiff: ConvertToPngUrl,
+  convertHeic: ConvertHeicToPngUrl,
+  convertTiff: ConvertTiffToPngUrl,
 ): Promise<string> => {
   if (isHeicUri(uri)) {
     try {
-      const blob = await readBlob(uri)
-      return await convertHeic(blob)
+      return await convertHeic(uri)
     } catch {
       return ''
     }

--- a/packages/extension/test/ConvertHeicToPngUrl.test.ts
+++ b/packages/extension/test/ConvertHeicToPngUrl.test.ts
@@ -1,15 +1,138 @@
-import { expect, jest, test } from '@jest/globals'
+import { beforeEach, expect, jest, test } from '@jest/globals'
 import { convertHeicToPngUrlWithDependencies } from '../src/parts/ConvertHeicToPngUrl/ConvertHeicToPngUrl.ts'
 
-test('creates an object URL for the converted PNG', async () => {
-  const heic = new Blob(['heic'], { type: 'image/heic' })
-  const png = new Blob(['png'], { type: 'image/png' })
-  const convert = jest.fn<(blob: Blob) => Promise<Blob>>().mockResolvedValue(png)
-  const createObjectUrl = jest.fn<(blob: Blob) => string>().mockReturnValue('blob:https://example.com/png-id')
+const uri = 'file:///workspace/image.heic'
+const hash = 'sha256-image-hash'
+const cacheKey = `https://media-preview-cache.invalid/heic-png/${hash}.png`
+const heic = new Blob(['heic'], { type: 'image/heic' })
+const png = new Blob(['png'], { type: 'image/png' })
+const convert = jest.fn<(blob: Blob) => Promise<Blob>>()
+const createObjectUrl = jest.fn<(blob: Blob) => string>()
+const getHash = jest.fn<(uri: string) => Promise<string>>()
+const getSetting = jest.fn<(key: string) => Promise<unknown>>()
+const readFileAsBlob = jest.fn<(uri: string) => Promise<Blob>>()
 
-  await expect(convertHeicToPngUrlWithDependencies(heic, convert, createObjectUrl)).resolves.toBe(
-    'blob:https://example.com/png-id',
-  )
+const createMemoryCacheStorage = (
+  initialValues: Readonly<Record<string, Response>> = {},
+): {
+  readonly cacheStorage: CacheStorage
+  readonly putKeys: readonly string[]
+} => {
+  const values = new Map<string, Response>(Object.entries(initialValues))
+  const putKeys: string[] = []
+  const cache = {
+    async match(key: string): Promise<Response | undefined> {
+      return values.get(key)?.clone()
+    },
+    async put(key: string, response: Response): Promise<void> {
+      putKeys.push(key)
+      values.set(key, response.clone())
+    },
+  } as unknown as Cache
+  const cacheStorage = {
+    async open(name: string): Promise<Cache> {
+      expect(name).toBe('builtin.media-preview.heic-png-v1')
+      return cache
+    },
+  } as unknown as CacheStorage
+  return { cacheStorage, putKeys }
+}
+
+beforeEach(() => {
+  jest.resetAllMocks()
+  convert.mockResolvedValue(png)
+  createObjectUrl.mockReturnValue('blob:https://example.com/png-id')
+  getHash.mockResolvedValue(hash)
+  readFileAsBlob.mockResolvedValue(heic)
+})
+
+test('converts without querying the hash or cache when caching is disabled', async () => {
+  getSetting.mockResolvedValue(false)
+  const { cacheStorage, putKeys } = createMemoryCacheStorage()
+
+  await expect(
+    convertHeicToPngUrlWithDependencies(uri, {
+      cacheStorage,
+      convert,
+      createUrl: createObjectUrl,
+      getHash,
+      getSetting,
+      readBlob: readFileAsBlob,
+    }),
+  ).resolves.toBe('blob:https://example.com/png-id')
+
+  expect(getSetting).toHaveBeenCalledWith('mediaPreview.cachingEnabled')
+  expect(getHash).not.toHaveBeenCalled()
+  expect(putKeys).toEqual([])
+  expect(readFileAsBlob).toHaveBeenCalledWith(uri)
   expect(convert).toHaveBeenCalledWith(heic)
   expect(createObjectUrl).toHaveBeenCalledWith(png)
+})
+
+test('uses the cached PNG before reading the HEIC blob when caching is enabled', async () => {
+  getSetting.mockResolvedValue(true)
+  const cachedPng = new Blob(['cached png'], { type: 'image/png' })
+  const { cacheStorage, putKeys } = createMemoryCacheStorage({
+    [cacheKey]: new Response(cachedPng),
+  })
+
+  await expect(
+    convertHeicToPngUrlWithDependencies(uri, {
+      cacheStorage,
+      convert,
+      createUrl: createObjectUrl,
+      getHash,
+      getSetting,
+      readBlob: readFileAsBlob,
+    }),
+  ).resolves.toBe('blob:https://example.com/png-id')
+
+  expect(getHash).toHaveBeenCalledWith(uri)
+  expect(readFileAsBlob).not.toHaveBeenCalled()
+  expect(convert).not.toHaveBeenCalled()
+  expect(putKeys).toEqual([])
+  expect(createObjectUrl).toHaveBeenCalledTimes(1)
+  expect(await createObjectUrl.mock.calls[0][0].text()).toBe('cached png')
+})
+
+test('converts and caches the PNG after a cache miss', async () => {
+  getSetting.mockResolvedValue(true)
+  const { cacheStorage, putKeys } = createMemoryCacheStorage()
+
+  await expect(
+    convertHeicToPngUrlWithDependencies(uri, {
+      cacheStorage,
+      convert,
+      createUrl: createObjectUrl,
+      getHash,
+      getSetting,
+      readBlob: readFileAsBlob,
+    }),
+  ).resolves.toBe('blob:https://example.com/png-id')
+
+  expect(getHash).toHaveBeenCalledWith(uri)
+  expect(readFileAsBlob).toHaveBeenCalledWith(uri)
+  expect(getHash.mock.invocationCallOrder[0]).toBeLessThan(readFileAsBlob.mock.invocationCallOrder[0])
+  expect(convert).toHaveBeenCalledWith(heic)
+  expect(putKeys).toEqual([cacheKey])
+  expect(createObjectUrl).toHaveBeenCalledWith(png)
+})
+
+test('falls back to conversion when Cache Storage is unavailable', async () => {
+  getSetting.mockResolvedValue(true)
+
+  await expect(
+    convertHeicToPngUrlWithDependencies(uri, {
+      cacheStorage: undefined,
+      convert,
+      createUrl: createObjectUrl,
+      getHash,
+      getSetting,
+      readBlob: readFileAsBlob,
+    }),
+  ).resolves.toBe('blob:https://example.com/png-id')
+
+  expect(getHash).toHaveBeenCalledWith(uri)
+  expect(readFileAsBlob).toHaveBeenCalledWith(uri)
+  expect(convert).toHaveBeenCalledWith(heic)
 })

--- a/packages/extension/test/ExtensionManifest.test.ts
+++ b/packages/extension/test/ExtensionManifest.test.ts
@@ -2,6 +2,7 @@ import { expect, test } from '@jest/globals'
 import { readFileSync } from 'node:fs'
 
 interface ExtensionManifest {
+  readonly configuration: Readonly<Record<string, { readonly default: unknown; readonly type: string }>>
   readonly workerName: string
 }
 
@@ -10,4 +11,13 @@ const manifest = JSON.parse(readFileSync(manifestUrl, 'utf8')) as ExtensionManif
 
 test('uses the media preview worker name', () => {
   expect(manifest.workerName).toBe('Media Preview Worker')
+})
+
+test('defines HEIC conversion caching as disabled by default', () => {
+  expect(manifest.configuration['mediaPreview.cachingEnabled']).toEqual(
+    expect.objectContaining({
+      default: false,
+      type: 'boolean',
+    }),
+  )
 })

--- a/packages/extension/test/GetUrl.test.ts
+++ b/packages/extension/test/GetUrl.test.ts
@@ -4,7 +4,7 @@ import { getUrlWithDependencies } from '../src/parts/GetUrl/GetUrl.ts'
 
 const readAsObjectUrl = jest.fn<(uri: string) => Promise<ReadAsObjectUrlResult>>()
 const readFileAsBlob = jest.fn<(uri: string) => Promise<Blob>>()
-const convertHeicToPngUrl = jest.fn<(blob: Blob) => Promise<string>>()
+const convertHeicToPngUrl = jest.fn<(uri: string) => Promise<string>>()
 const convertTiffToPngUrl = jest.fn<(blob: Blob) => Promise<string>>()
 
 beforeEach(() => {
@@ -54,8 +54,6 @@ test('returns an empty URL when the file could not be read', async () => {
 })
 
 test('converts lowercase HEIC images to PNG', async () => {
-  const heic = new Blob(['heic'], { type: 'image/heic' })
-  readFileAsBlob.mockResolvedValue(heic)
   convertHeicToPngUrl.mockResolvedValue('blob:https://example.com/png-id')
 
   await expect(
@@ -68,13 +66,11 @@ test('converts lowercase HEIC images to PNG', async () => {
     ),
   ).resolves.toBe('blob:https://example.com/png-id')
   expect(readAsObjectUrl).not.toHaveBeenCalled()
-  expect(readFileAsBlob).toHaveBeenCalledWith('html:///workspace/image.heic')
-  expect(convertHeicToPngUrl).toHaveBeenCalledWith(heic)
+  expect(readFileAsBlob).not.toHaveBeenCalled()
+  expect(convertHeicToPngUrl).toHaveBeenCalledWith('html:///workspace/image.heic')
 })
 
 test('converts uppercase HEIC images to PNG', async () => {
-  const heic = new Blob(['heic'], { type: 'image/heic' })
-  readFileAsBlob.mockResolvedValue(heic)
   convertHeicToPngUrl.mockResolvedValue('blob:https://example.com/png-id')
 
   await expect(
@@ -87,12 +83,12 @@ test('converts uppercase HEIC images to PNG', async () => {
     ),
   ).resolves.toBe('blob:https://example.com/png-id')
   expect(readAsObjectUrl).not.toHaveBeenCalled()
-  expect(readFileAsBlob).toHaveBeenCalledWith('html:///workspace/image.HEIC')
-  expect(convertHeicToPngUrl).toHaveBeenCalledWith(heic)
+  expect(readFileAsBlob).not.toHaveBeenCalled()
+  expect(convertHeicToPngUrl).toHaveBeenCalledWith('html:///workspace/image.HEIC')
 })
 
 test('returns an empty URL when a HEIC image cannot be read', async () => {
-  readFileAsBlob.mockRejectedValue(new Error('File not found'))
+  convertHeicToPngUrl.mockRejectedValue(new Error('File not found'))
 
   await expect(
     getUrlWithDependencies(
@@ -103,12 +99,10 @@ test('returns an empty URL when a HEIC image cannot be read', async () => {
       convertTiffToPngUrl,
     ),
   ).resolves.toBe('')
-  expect(convertHeicToPngUrl).not.toHaveBeenCalled()
+  expect(convertHeicToPngUrl).toHaveBeenCalledWith('html:///workspace/missing.heic')
 })
 
 test('converts HEIF images to PNG', async () => {
-  const heif = new Blob(['heif'], { type: 'image/heif' })
-  readFileAsBlob.mockResolvedValue(heif)
   convertHeicToPngUrl.mockResolvedValue('blob:https://example.com/png-id')
 
   await expect(
@@ -121,8 +115,8 @@ test('converts HEIF images to PNG', async () => {
     ),
   ).resolves.toBe('blob:https://example.com/png-id')
   expect(readAsObjectUrl).not.toHaveBeenCalled()
-  expect(readFileAsBlob).toHaveBeenCalledWith('html:///workspace/image.HEIF')
-  expect(convertHeicToPngUrl).toHaveBeenCalledWith(heif)
+  expect(readFileAsBlob).not.toHaveBeenCalled()
+  expect(convertHeicToPngUrl).toHaveBeenCalledWith('html:///workspace/image.HEIF')
 })
 
 test.each(['image.tif', 'image.TIFF'])('converts TIFF images to PNG: %s', async (fileName) => {


### PR DESCRIPTION
Adds the disabled-by-default mediaPreview.cachingEnabled setting. When enabled, HEIC and HEIF previews reuse content-addressed PNG blobs from Cache Storage or cache newly converted PNGs before displaying them.