### PR TITLE
feature: navigate media previews with arrow keys

### DIFF
--- a/packages/e2e/src/media-preview-focused-on-open.ts
+++ b/packages/e2e/src/media-preview-focused-on-open.ts
@@ -1,0 +1,14 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'media-preview-focused-on-open'
+
+// Requires renderer-process support for focusing extension view roots.
+export const skip = true
+
+export const test: Test = async ({ expect, Locator, Main }) => {
+  const uri = import.meta.resolve('../files/file.png')
+  await Main.openUri(uri)
+
+  const preview = Locator('.MediaPreview')
+  await expect(preview).toBeFocused()
+}

--- a/packages/e2e/src/media-preview-keyboard-navigation.ts
+++ b/packages/e2e/src/media-preview-keyboard-navigation.ts
@@ -1,0 +1,37 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+const getSvg = (width: number): string => {
+  return `<svg width="${width}" height="100" viewBox="0 0 ${width} 100" xmlns="http://www.w3.org/2000/svg">
+  <rect width="${width}" height="100" fill="red" />
+</svg>`
+}
+
+export const name = 'media-preview-keyboard-navigation'
+
+export const test: Test = async ({ expect, FileSystem, KeyBoard, Locator, Main }) => {
+  const tmpDir = await FileSystem.getTmpDir()
+  await FileSystem.setFiles([
+    { content: getSvg(100), uri: `${tmpDir}/image1.svg` },
+    { content: getSvg(200), uri: `${tmpDir}/image2.svg` },
+    { content: getSvg(300), uri: `${tmpDir}/image10.svg` },
+    { content: 'not an image', uri: `${tmpDir}/notes.txt` },
+  ])
+  await Main.openUri(`${tmpDir}/image2.svg`)
+  const image = Locator('.MediaPreviewImage')
+  await expect(image).toHaveJSProperty('naturalWidth', 200)
+
+  await KeyBoard.press('ArrowRight')
+  await expect(image).toHaveJSProperty('naturalWidth', 300)
+
+  await KeyBoard.press('ArrowRight')
+  await expect(image).toHaveJSProperty('naturalWidth', 300)
+
+  await KeyBoard.press('ArrowLeft')
+  await expect(image).toHaveJSProperty('naturalWidth', 200)
+
+  await KeyBoard.press('ArrowLeft')
+  await expect(image).toHaveJSProperty('naturalWidth', 100)
+
+  await KeyBoard.press('ArrowLeft')
+  await expect(image).toHaveJSProperty('naturalWidth', 100)
+}

--- a/packages/e2e/src/media-preview-keyboard-navigation.ts
+++ b/packages/e2e/src/media-preview-keyboard-navigation.ts
@@ -8,7 +8,20 @@ const getSvg = (width: number): string => {
 
 export const name = 'media-preview-keyboard-navigation'
 
-export const test: Test = async ({ expect, FileSystem, KeyBoard, Locator, Main }) => {
+const waitForExpectation = async (assertion: () => Promise<void>): Promise<void> => {
+  for (let attempt = 0; attempt < 40; attempt++) {
+    try {
+      await assertion()
+      return
+    } catch {
+      await new Promise((resolve) => setTimeout(resolve, 50))
+    }
+  }
+  await assertion()
+}
+
+export const test: Test = async ({ Command, expect, FileSystem, KeyBoard, Locator, Main, Settings }) => {
+  await Settings.update({ 'statusBar.itemsVisible': true })
   const tmpDir = await FileSystem.getTmpDir()
   await FileSystem.setFiles([
     { content: getSvg(100), uri: `${tmpDir}/image1.svg` },
@@ -17,21 +30,28 @@ export const test: Test = async ({ expect, FileSystem, KeyBoard, Locator, Main }
     { content: 'not an image', uri: `${tmpDir}/notes.txt` },
   ])
   await Main.openUri(`${tmpDir}/image2.svg`)
+  const preview = Locator('.MediaPreview')
   const image = Locator('.MediaPreviewImage')
+  const dimensions = Locator('.StatusBarItem[name="media-preview-dimensions"]')
+  const states = await Command.execute('Viewlet.getAllStates')
+  const mediaPreview = Object.values(states).find(({ viewId }: any) => viewId === 'builtin.media-preview') as any
+  await Command.execute('Viewlet.focusSelector', mediaPreview.uid, '.MediaPreview')
+  await expect(preview).toBeFocused()
   await expect(image).toHaveJSProperty('naturalWidth', 200)
+  await waitForExpectation(() => expect(dimensions).toHaveText('200 × 100'))
 
   await KeyBoard.press('ArrowRight')
-  await expect(image).toHaveJSProperty('naturalWidth', 300)
+  await waitForExpectation(() => expect(dimensions).toHaveText('300 × 100'))
 
   await KeyBoard.press('ArrowRight')
-  await expect(image).toHaveJSProperty('naturalWidth', 300)
+  await expect(dimensions).toHaveText('300 × 100')
 
   await KeyBoard.press('ArrowLeft')
-  await expect(image).toHaveJSProperty('naturalWidth', 200)
+  await waitForExpectation(() => expect(dimensions).toHaveText('200 × 100'))
 
   await KeyBoard.press('ArrowLeft')
-  await expect(image).toHaveJSProperty('naturalWidth', 100)
+  await waitForExpectation(() => expect(dimensions).toHaveText('100 × 100'))
 
   await KeyBoard.press('ArrowLeft')
-  await expect(image).toHaveJSProperty('naturalWidth', 100)
+  await expect(dimensions).toHaveText('100 × 100')
 }

--- a/packages/extension/extension.json
+++ b/packages/extension/extension.json
@@ -37,6 +37,10 @@
           "params": ["handleMediaPreviewImageLoad", "event.currentTarget.naturalWidth", "event.currentTarget.naturalHeight"]
         },
         {
+          "name": "handleMediaPreviewKeyDown",
+          "params": ["handleMediaPreviewKeyDown", "event.key"]
+        },
+        {
           "name": "handleMediaPreviewPointerDown",
           "params": ["handleMediaPreviewPointerDown", "event.button", "event.clientX", "event.clientY"],
           "preventDefault": true,

--- a/packages/extension/src/parts/GetSiblingImageUris/GetSiblingImageUris.ts
+++ b/packages/extension/src/parts/GetSiblingImageUris/GetSiblingImageUris.ts
@@ -1,0 +1,113 @@
+import { readDirWithFileTypes, type FileSystemDirent } from '@lvce-editor/api'
+
+// cspell:ignore apng jfif
+
+type ReadDirWithFileTypes = (uri: string) => Promise<readonly FileSystemDirent[]>
+
+interface UriParts {
+  readonly baseName: string
+  readonly join: (name: string) => string
+  readonly parentUri: string
+}
+
+const imageExtensions = new Set([
+  '.apng',
+  '.avif',
+  '.bmp',
+  '.gif',
+  '.heic',
+  '.heif',
+  '.ico',
+  '.jpe',
+  '.jfif',
+  '.jpeg',
+  '.jpg',
+  '.png',
+  '.svg',
+  '.tif',
+  '.tiff',
+  '.webp',
+])
+
+const uriSchemePattern = /^[a-z][a-z\d+.-]*:\/\//i
+
+const decodePathSegment = (value: string): string => {
+  try {
+    return decodeURIComponent(value)
+  } catch {
+    return value
+  }
+}
+
+const getUrlParts = (uri: string): UriParts | undefined => {
+  try {
+    const url = new URL(uri)
+    const slashIndex = url.pathname.lastIndexOf('/')
+    if (slashIndex === -1) {
+      return undefined
+    }
+    const baseName = decodePathSegment(url.pathname.slice(slashIndex + 1))
+    url.pathname = url.pathname.slice(0, slashIndex + 1)
+    url.hash = ''
+    url.search = ''
+    const parentUri = url.href
+    return {
+      baseName,
+      join: (name: string): string => new URL(encodeURIComponent(name), parentUri).href,
+      parentUri,
+    }
+  } catch {
+    return undefined
+  }
+}
+
+const getPathParts = (uri: string): UriParts | undefined => {
+  const slashIndex = uri.lastIndexOf('/')
+  const backslashIndex = uri.lastIndexOf('\\')
+  const separatorIndex = Math.max(slashIndex, backslashIndex)
+  if (separatorIndex === -1) {
+    return undefined
+  }
+  const parentUri = uri.slice(0, separatorIndex + 1)
+  return {
+    baseName: uri.slice(separatorIndex + 1),
+    join: (name: string): string => `${parentUri}${name}`,
+    parentUri,
+  }
+}
+
+const getUriParts = (uri: string): UriParts | undefined => {
+  return uriSchemePattern.test(uri) ? getUrlParts(uri) : getPathParts(uri)
+}
+
+const isImage = (name: string): boolean => {
+  const dotIndex = name.lastIndexOf('.')
+  return dotIndex !== -1 && imageExtensions.has(name.slice(dotIndex).toLowerCase())
+}
+
+const compareNames = (a: string, b: string): number => {
+  return a.localeCompare(b, 'en', { numeric: true })
+}
+
+export const getSiblingImageUrisWithDependency = async (
+  uri: string,
+  readDirectory: ReadDirWithFileTypes,
+): Promise<readonly string[]> => {
+  const parts = getUriParts(uri)
+  if (!parts) {
+    return []
+  }
+  const entries = await readDirectory(parts.parentUri)
+  const imageNames = entries
+    .map((entry) => entry.name)
+    .filter(isImage)
+    .toSorted(compareNames)
+  if (!imageNames.includes(parts.baseName)) {
+    return []
+  }
+  return imageNames.map(parts.join)
+}
+
+export const getSiblingImageUris = (uri: string): Promise<readonly string[]> => {
+  return getSiblingImageUrisWithDependency(uri, readDirWithFileTypes)
+}

--- a/packages/extension/src/parts/MediaPreview/MediaPreview.ts
+++ b/packages/extension/src/parts/MediaPreview/MediaPreview.ts
@@ -43,6 +43,7 @@ const wrapCommand = (fn: (id: number, ...params: readonly any[]) => unknown) => 
 
 export { getUrl } from '../GetUrl/GetUrl.ts'
 export { getFileSize } from '../GetFileSize/GetFileSize.ts'
+export { getSiblingImageUris } from '../GetSiblingImageUris/GetSiblingImageUris.ts'
 export { exists } from '@lvce-editor/api'
 export { saveState } from '../SaveState/SaveState.ts'
 export { setSavedState } from '../SetSavedState/SetSavedState.ts'

--- a/packages/extension/src/parts/MediaPreviewView/MediaPreviewView.ts
+++ b/packages/extension/src/parts/MediaPreviewView/MediaPreviewView.ts
@@ -22,6 +22,10 @@ export const view: View<MediaPreviewViewInstance> = {
       preventDefault: true,
     },
     {
+      name: 'handleMediaPreviewKeyDown',
+      params: ['handleMediaPreviewKeyDown', 'event.key'],
+    },
+    {
       name: 'handleMediaPreviewPointerDown',
       params: ['handleMediaPreviewPointerDown', 'event.button', 'event.clientX', 'event.clientY'],
       preventDefault: true,

--- a/packages/extension/src/parts/MediaPreviewViewInstance/MediaPreviewViewInstance.ts
+++ b/packages/extension/src/parts/MediaPreviewViewInstance/MediaPreviewViewInstance.ts
@@ -33,6 +33,7 @@ export interface MediaPreviewViewInstance extends VirtualDomViewInstance {
   readonly getMenuEntries: (menuId: string) => Promise<readonly MenuEntry[]>
   readonly handleMediaPreviewImageError: () => Promise<void>
   readonly handleMediaPreviewImageLoad: (width: unknown, height: unknown) => void
+  readonly handleMediaPreviewKeyDown: (key: unknown) => Promise<void>
   readonly handleMediaPreviewPointerDown: (button: unknown, x: unknown, y: unknown) => void
   readonly handleMediaPreviewPointerMove: (x: unknown, y: unknown) => void
   readonly handleMediaPreviewPointerUp: (x: unknown, y: unknown) => void
@@ -48,6 +49,7 @@ interface MediaPreviewApi {
   readonly dispose: (id: number) => unknown
   readonly exists: (uri: string) => Promise<boolean>
   readonly getFileSize: (uri: string) => Promise<number>
+  readonly getSiblingImageUris: (uri: string) => Promise<readonly string[]>
   readonly getState: (id: number) => Pick<MediaPreviewState, 'domMatrixString' | 'error' | 'pointerDown'>
   readonly getUrl: (uri: string) => Promise<string>
   readonly handleError: (id: number) => Partial<MediaPreviewState>
@@ -99,7 +101,7 @@ export const createInstanceWithApi = async (
 ): Promise<MediaPreviewViewInstance> => {
   const viewContext: MediaPreviewViewContext | undefined = context
   const id = viewContext?.uid ?? 0
-  const uri = getUri(viewContext)
+  let uri = getUri(viewContext)
   api.create(id)
   api.setSavedState(id, context?.state)
   const previewState = api.getState(id)
@@ -116,6 +118,8 @@ export const createInstanceWithApi = async (
     url,
     width: 0,
   }
+  let siblingImageUrisPromise: Promise<readonly string[]> | undefined
+  let navigationPromise = Promise.resolve()
 
   const updateState = (newState: Partial<MediaPreviewState>): void => {
     state = {
@@ -133,9 +137,66 @@ export const createInstanceWithApi = async (
     })
   }
 
+  const loadSiblingImageUris = async (): Promise<readonly string[]> => {
+    try {
+      return await api.getSiblingImageUris(uri)
+    } catch {
+      return []
+    }
+  }
+
+  const getSiblingImageUris = (): Promise<readonly string[]> => {
+    siblingImageUrisPromise ||= loadSiblingImageUris()
+    return siblingImageUrisPromise
+  }
+
+  const navigateToSibling = async (offset: number): Promise<void> => {
+    const siblingImageUris = await getSiblingImageUris()
+    const currentIndex = siblingImageUris.indexOf(uri)
+    const nextUri = siblingImageUris[currentIndex + offset]
+    if (!nextUri || currentIndex === -1) {
+      return
+    }
+    uri = nextUri
+    api.create(id)
+    const previewState = api.getState(id)
+    const [url, fileSize] = await Promise.all([api.getUrl(uri), api.getFileSize(uri)])
+    const error = !url || previewState.error
+    const errorMessage = error ? await getImageErrorMessage(uri, api.exists) : ''
+    updateState({
+      ...previewState,
+      canOpenAsText: canOpenAsText(uri, errorMessage),
+      error,
+      errorMessage,
+      fileSize,
+      height: 0,
+      url,
+      width: 0,
+    })
+  }
+
+  const queueNavigation = async (offset: number): Promise<void> => {
+    const previousNavigation = navigationPromise
+    const navigation = async (): Promise<void> => {
+      try {
+        await previousNavigation
+      } catch {
+        // Keep later key presses usable if an image failed to load.
+      }
+      await navigateToSibling(offset)
+    }
+    navigationPromise = navigation()
+    await navigationPromise
+  }
+
   return {
     dispose(): void {
       api.dispose(id)
+    },
+    getContext(): Readonly<Record<string, boolean>> {
+      return {
+        mediaPreviewFocus: true,
+      }
     },
     getCss(): string {
       const { domMatrixString } = state
@@ -199,6 +260,13 @@ export const createInstanceWithApi = async (
         width: getNumber(width),
       })
     },
+    async handleMediaPreviewKeyDown(key: unknown): Promise<void> {
+      if (key === 'ArrowLeft') {
+        await queueNavigation(-1)
+      } else if (key === 'ArrowRight') {
+        await queueNavigation(1)
+      }
+    },
     handleMediaPreviewPointerDown(button: unknown, x: unknown, y: unknown): void {
       if (button !== 0) {
         return
@@ -219,6 +287,9 @@ export const createInstanceWithApi = async (
     },
     render(): readonly VirtualDomNode[] {
       return render(state)
+    },
+    renderFocus(): string {
+      return '.MediaPreview'
     },
     renderStatusBarItems(): readonly StatusBarItem[] {
       return renderStatusBarItems(state)

--- a/packages/extension/src/parts/MediaPreviewViewInstance/MediaPreviewViewInstance.ts
+++ b/packages/extension/src/parts/MediaPreviewViewInstance/MediaPreviewViewInstance.ts
@@ -193,11 +193,6 @@ export const createInstanceWithApi = async (
     dispose(): void {
       api.dispose(id)
     },
-    getContext(): Readonly<Record<string, boolean>> {
-      return {
-        mediaPreviewFocus: true,
-      }
-    },
     getCss(): string {
       const { domMatrixString } = state
       return getCss(domMatrixString)
@@ -287,9 +282,6 @@ export const createInstanceWithApi = async (
     },
     render(): readonly VirtualDomNode[] {
       return render(state)
-    },
-    renderFocus(): string {
-      return '.MediaPreview'
     },
     renderStatusBarItems(): readonly StatusBarItem[] {
       return renderStatusBarItems(state)

--- a/packages/extension/src/parts/RenderMediaPreview/RenderMediaPreview.ts
+++ b/packages/extension/src/parts/RenderMediaPreview/RenderMediaPreview.ts
@@ -2,9 +2,11 @@ import { VirtualDomElements, type VirtualDomNode } from '@lvce-editor/virtual-do
 import type { MediaPreviewState } from '../MediaPreviewViewInstance/MediaPreviewViewInstance.ts'
 import { renderError } from '../RenderError/RenderError.ts'
 import { renderImage } from '../RenderImage/RenderImage.ts'
+import * as TabIndex from '../TabIndex/TabIndex.ts'
 
 const handleMediaPreviewPointerDown = 'handleMediaPreviewPointerDown'
 const handleMediaPreviewWheel = 'handleMediaPreviewWheel'
+const handleMediaPreviewKeyDown = 'handleMediaPreviewKeyDown'
 
 export const render = (state: Readonly<MediaPreviewState>): readonly VirtualDomNode[] => {
   const { error, pointerDown } = state
@@ -14,13 +16,17 @@ export const render = (state: Readonly<MediaPreviewState>): readonly VirtualDomN
     ? {
         childCount: 1,
         className,
+        onKeyDown: handleMediaPreviewKeyDown,
+        tabIndex: TabIndex.Focusable,
         type: VirtualDomElements.Div,
       }
     : {
         childCount: 1,
         className,
+        onKeyDown: handleMediaPreviewKeyDown,
         onPointerDown: handleMediaPreviewPointerDown,
         onWheel: handleMediaPreviewWheel,
+        tabIndex: TabIndex.Focusable,
         type: VirtualDomElements.Div,
       }
   return [rootNode, ...content]

--- a/packages/extension/src/parts/TabIndex/TabIndex.ts
+++ b/packages/extension/src/parts/TabIndex/TabIndex.ts
@@ -1,0 +1,1 @@
+export const Focusable = 0

--- a/packages/extension/test/GetSiblingImageUris.test.ts
+++ b/packages/extension/test/GetSiblingImageUris.test.ts
@@ -1,0 +1,63 @@
+import type { FileSystemDirent } from '@lvce-editor/api'
+import { expect, jest, test } from '@jest/globals'
+import { getSiblingImageUrisWithDependency } from '../src/parts/GetSiblingImageUris/GetSiblingImageUris.ts'
+
+const file = (name: string): FileSystemDirent => ({ name, type: 7 })
+
+test('returns naturally sorted image siblings for a path', async () => {
+  const readDirectory = jest.fn(async (_uri: string) => [
+    file('image10.png'),
+    file('notes.txt'),
+    file('image2.JPG'),
+    file('image1.svg'),
+  ])
+
+  await expect(getSiblingImageUrisWithDependency('/workspace/image2.JPG', readDirectory)).resolves.toEqual([
+    '/workspace/image1.svg',
+    '/workspace/image2.JPG',
+    '/workspace/image10.png',
+  ])
+  expect(readDirectory).toHaveBeenCalledWith('/workspace/')
+})
+
+test('preserves encoded file uris', async () => {
+  const readDirectory = jest.fn(async (_uri: string) => [file('first image.png'), file('second # image.webp')])
+
+  await expect(getSiblingImageUrisWithDependency('file:///pictures/first%20image.png', readDirectory)).resolves.toEqual([
+    'file:///pictures/first%20image.png',
+    'file:///pictures/second%20%23%20image.webp',
+  ])
+  expect(readDirectory).toHaveBeenCalledWith('file:///pictures/')
+})
+
+test('supports windows paths', async () => {
+  const readDirectory = jest.fn(async (_uri: string) => [file('a.png'), file('b.gif')])
+
+  await expect(getSiblingImageUrisWithDependency('C:\\pictures\\b.gif', readDirectory)).resolves.toEqual([
+    'C:\\pictures\\a.png',
+    'C:\\pictures\\b.gif',
+  ])
+  expect(readDirectory).toHaveBeenCalledWith('C:\\pictures\\')
+})
+
+test('returns no siblings when the uri has no parent', async () => {
+  const readDirectory = jest.fn(async (_uri: string) => [file('image.png')])
+
+  await expect(getSiblingImageUrisWithDependency('image.png', readDirectory)).resolves.toEqual([])
+  expect(readDirectory).not.toHaveBeenCalled()
+})
+
+test('returns no siblings when the current image is absent', async () => {
+  const readDirectory = jest.fn(async (_uri: string) => [file('other.png')])
+
+  await expect(getSiblingImageUrisWithDependency('/workspace/image.png', readDirectory)).resolves.toEqual([])
+})
+
+test('handles malformed uri encoding', async () => {
+  const readDirectory = jest.fn(async (_uri: string) => [file('%image.png'), file('other.png')])
+
+  await expect(getSiblingImageUrisWithDependency('file:///pictures/%image.png', readDirectory)).resolves.toEqual([
+    'file:///pictures/%25image.png',
+    'file:///pictures/other.png',
+  ])
+})

--- a/packages/extension/test/MediaPreviewView.test.ts
+++ b/packages/extension/test/MediaPreviewView.test.ts
@@ -14,9 +14,14 @@ test('contributes a virtual dom media preview view', () => {
     'handleMediaPreviewImageError',
     'handleMediaPreviewImageLoad',
     'handleOpenInTextEditor',
+    'handleMediaPreviewKeyDown',
     'handleMediaPreviewPointerDown',
     'handleMediaPreviewPointerMove',
     'handleMediaPreviewPointerUp',
     'handleMediaPreviewWheel',
+  ])
+  expect(view.eventListeners?.find((listener) => listener.name === 'handleMediaPreviewKeyDown')?.params).toEqual([
+    'handleMediaPreviewKeyDown',
+    'event.key',
   ])
 })

--- a/packages/extension/test/MediaPreviewViewInstance.test.ts
+++ b/packages/extension/test/MediaPreviewViewInstance.test.ts
@@ -20,6 +20,7 @@ const createApi = (): MockMediaPreviewApi => {
     dispose: jest.fn((_id: number) => {}),
     exists: jest.fn(async (_uri: string) => true),
     getFileSize: jest.fn(async (_uri: string) => 512_596),
+    getSiblingImageUris: jest.fn(async (uri: string) => [uri]),
     getState: jest.fn((_id: number) => initialState),
     getUrl: jest.fn(async (_uri: string) => 'blob:https://example.com/image-id'),
     handleError: jest.fn((_id: number) => ({ ...initialState, error: true })),
@@ -52,6 +53,71 @@ test('creates a preview and renders its image', async () => {
   expect(instance.getCss()).toBe(`.MediaPreview {
   --MediaPreviewTransform: matrix(1, 0, 0, 1, 0, 0);
 }`)
+  expect(instance.getContext?.()).toEqual({ mediaPreviewFocus: true })
+  expect(instance.renderFocus?.({}, {})).toBe('.MediaPreview')
+})
+
+test('navigates to the next and previous image and resets the preview state', async () => {
+  const api = createApi()
+  api.getSiblingImageUris.mockResolvedValue(['/workspace/image1.png', '/workspace/image2.png', '/workspace/image10.png'])
+  api.getUrl.mockImplementation(async (uri: string) => `blob:${uri}`)
+  api.getFileSize.mockImplementation(async (uri: string) => (uri.endsWith('image2.png') ? 200 : 100))
+  api.handleWheel.mockReturnValue({
+    ...initialState,
+    domMatrixString: 'matrix(2, 0, 0, 2, 10, 20)',
+  })
+  const image2Context = {
+    ...context,
+    uri: '/workspace/image2.png',
+  } as unknown as ViewContext
+  const instance = await createInstanceWithApi(image2Context, api)
+  instance.handleMediaPreviewWheel(70, 0)
+
+  await instance.handleMediaPreviewKeyDown('ArrowRight')
+
+  expect(api.getSiblingImageUris).toHaveBeenCalledTimes(1)
+  expect(api.getSiblingImageUris).toHaveBeenCalledWith('/workspace/image2.png')
+  expect(api.create).toHaveBeenCalledTimes(2)
+  expect(api.getUrl).toHaveBeenLastCalledWith('/workspace/image10.png')
+  expect(instance.render().some((node) => node.src === 'blob:/workspace/image10.png')).toBe(true)
+  expect(instance.getCss()).toBe(`.MediaPreview {
+  --MediaPreviewTransform: matrix(1, 0, 0, 1, 0, 0);
+}`)
+
+  await instance.handleMediaPreviewKeyDown('ArrowLeft')
+
+  expect(api.getSiblingImageUris).toHaveBeenCalledTimes(1)
+  expect(api.getUrl).toHaveBeenLastCalledWith('/workspace/image2.png')
+  expect(instance.renderStatusBarItems()[1]?.text).toBe('200 B')
+})
+
+test('does nothing at image boundaries or for unrelated keys', async () => {
+  const api = createApi()
+  api.getSiblingImageUris.mockResolvedValue(['/workspace/image.png', '/workspace/next.png'])
+  const instance = await createInstanceWithApi(context, api)
+
+  await instance.handleMediaPreviewKeyDown('ArrowLeft')
+  await instance.handleMediaPreviewKeyDown('ArrowUp')
+
+  expect(api.create).toHaveBeenCalledTimes(1)
+  expect(api.getUrl).toHaveBeenCalledTimes(1)
+
+  await instance.handleMediaPreviewKeyDown('ArrowRight')
+  await instance.handleMediaPreviewKeyDown('ArrowRight')
+
+  expect(api.create).toHaveBeenCalledTimes(2)
+  expect(api.getUrl).toHaveBeenCalledTimes(2)
+})
+
+test('does nothing when sibling discovery fails', async () => {
+  const api = createApi()
+  api.getSiblingImageUris.mockRejectedValue(new Error('filesystem unavailable'))
+  const instance = await createInstanceWithApi(context, api)
+
+  await instance.handleMediaPreviewKeyDown('ArrowRight')
+
+  expect(api.create).toHaveBeenCalledTimes(1)
+  expect(api.getUrl).toHaveBeenCalledTimes(1)
 })
 
 test('renders a load error when the image URL cannot be read but the file exists', async () => {
@@ -265,6 +331,25 @@ test('saves the URI with preview state and disposes the preview instance', async
   })
   await instance.dispose?.()
   expect(api.dispose).toHaveBeenCalledWith(7)
+})
+
+test('saves and copies the navigated image URI', async () => {
+  const api = createApi()
+  api.getSiblingImageUris.mockResolvedValue(['/workspace/image.png', '/workspace/next.png'])
+  const instance = await createInstanceWithApi(context, api)
+
+  await instance.handleMediaPreviewKeyDown('ArrowRight')
+
+  await expect(instance.saveState()).resolves.toEqual({
+    domMatrix: initialState.domMatrixString,
+    uri: '/workspace/next.png',
+  })
+  await expect(instance.getMenuEntries('mediaPreview.image')).resolves.toContainEqual({
+    args: ['/workspace/next.png'],
+    command: 'ClipBoard.writeText',
+    id: 'copyPath',
+    label: 'Copy Path',
+  })
 })
 
 test('forwards legacy view events and normalizes invalid coordinates', async () => {

--- a/packages/extension/test/MediaPreviewViewInstance.test.ts
+++ b/packages/extension/test/MediaPreviewViewInstance.test.ts
@@ -53,8 +53,6 @@ test('creates a preview and renders its image', async () => {
   expect(instance.getCss()).toBe(`.MediaPreview {
   --MediaPreviewTransform: matrix(1, 0, 0, 1, 0, 0);
 }`)
-  expect(instance.getContext?.()).toEqual({ mediaPreviewFocus: true })
-  expect(instance.renderFocus?.({}, {})).toBe('.MediaPreview')
 })
 
 test('navigates to the next and previous image and resets the preview state', async () => {

--- a/packages/extension/test/RenderMediaPreview.test.ts
+++ b/packages/extension/test/RenderMediaPreview.test.ts
@@ -1,6 +1,7 @@
 import { expect, test } from '@jest/globals'
 import { mergeClassNames, VirtualDomElements } from '@lvce-editor/virtual-dom-worker'
 import { render } from '../src/parts/RenderMediaPreview/RenderMediaPreview.ts'
+import * as TabIndex from '../src/parts/TabIndex/TabIndex.ts'
 
 const state = {
   canOpenAsText: false,
@@ -21,8 +22,10 @@ test('renders the image inside a wrapper', () => {
     {
       childCount: 1,
       className: 'MediaPreview',
+      onKeyDown: 'handleMediaPreviewKeyDown',
       onPointerDown: 'handleMediaPreviewPointerDown',
       onWheel: 'handleMediaPreviewWheel',
+      tabIndex: TabIndex.Focusable,
       type: VirtualDomElements.Div,
     },
     {
@@ -61,6 +64,8 @@ test('renders an error without an image', () => {
     {
       childCount: 1,
       className: 'MediaPreview',
+      onKeyDown: 'handleMediaPreviewKeyDown',
+      tabIndex: TabIndex.Focusable,
       type: VirtualDomElements.Div,
     },
     {


### PR DESCRIPTION
Add left/right keyboard navigation between naturally sorted images in the current folder.

Keep the existing tab title while updating the preview URL, dimensions, size, and resetting zoom/position for each image.