### PR TITLE
fix: show active image status items

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2871,9 +2871,9 @@
       "optional": true
     },
     "node_modules/@lvce-editor/api": {
-      "version": "9.16.1",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/api/-/api-9.16.1.tgz",
-      "integrity": "sha512-9ijFWJF7Hc5GpBjVdDspiZYC5ojMWZaLTY/2nEPOuF0+7jaMiFdakuuZxcNS1HHooIx4xCxPCUHECuIZFPUPnA==",
+      "version": "9.16.2",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/api/-/api-9.16.2.tgz",
+      "integrity": "sha512-7x7QXFcZwzAef938iS9WJ0mCvJDbkNcOViMkNPlYXQ7iW2P9ll6T1ERLhIl5h7TeYjZYb5+oqwxD/cOFsGeNkw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -15592,7 +15592,7 @@
       "license": "MIT",
       "devDependencies": {
         "@jest/globals": "^30.4.1",
-        "@lvce-editor/api": "^9.16.1",
+        "@lvce-editor/api": "^9.16.2",
         "@lvce-editor/virtual-dom-worker": "^11.12.2"
       }
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -2906,16 +2906,16 @@
       "license": "MIT"
     },
     "node_modules/@lvce-editor/constants": {
-      "version": "5.26.0",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/constants/-/constants-5.26.0.tgz",
-      "integrity": "sha512-vh+dSf+oLjS+ekKOnHHDuP8NUSM3ps/Ir15yCJlGDFw82ZqQeWqAiJyIx3Gsa2XDw77ZKDVfxr9wTHgPIaRu3g==",
+      "version": "5.28.0",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/constants/-/constants-5.28.0.tgz",
+      "integrity": "sha512-6ESs02HAc2xYkZjIZOy74SY7R19xXbetdBPkJUXZUTI7rozHrGSf9LkBHcyt7UB1gSct7z8LrVFesMdj2N6RLg==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@lvce-editor/embeds-process": {
-      "version": "4.15.0",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/embeds-process/-/embeds-process-4.15.0.tgz",
-      "integrity": "sha512-Z9B7YS7KAzia8lI1XR4Grx5Rl+OX2ow5PuAePLh1n4gx5BB40VeJX7Jj9scOZRclUQQmhCkH6MQt28jhIXNQ4A==",
+      "version": "4.16.0",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/embeds-process/-/embeds-process-4.16.0.tgz",
+      "integrity": "sha512-YCrIuadsm/gsRi2aX3RBj5cvPNUqWX7rENkpFHU1kMooDXv10CNcuJBQJqt/vFZfFp6UKI1bSyBBZV5PGQYebQ==",
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -3051,15 +3051,15 @@
       "license": "MIT"
     },
     "node_modules/@lvce-editor/extension-host-helper-process": {
-      "version": "0.100.3",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/extension-host-helper-process/-/extension-host-helper-process-0.100.3.tgz",
-      "integrity": "sha512-AzCbzrWkzWzs83tktFOoZbzVtuwJfDNpeZfCIdfIJ86rjRTIAxVDxO8HZnd7Yh9HecN+NZoC7JS8kpl4H/Rr2w==",
+      "version": "0.100.22",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/extension-host-helper-process/-/extension-host-helper-process-0.100.22.tgz",
+      "integrity": "sha512-Ui5spZrltro7N8yh59Q/qiHNQkdD7Y0LyI3tmgLpbjQgVhb8naqVpXymfX55DNAKL3/rUgHpSmu4lbtIEEoexQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@lvce-editor/assert": "^1.9.0",
         "@lvce-editor/command": "^2.0.0",
-        "@lvce-editor/rpc": "^6.16.0",
+        "@lvce-editor/rpc": "^6.18.0",
         "@lvce-editor/verror": "^1.7.0"
       },
       "engines": {
@@ -3067,9 +3067,9 @@
       }
     },
     "node_modules/@lvce-editor/file-system-process": {
-      "version": "5.12.0",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/file-system-process/-/file-system-process-5.12.0.tgz",
-      "integrity": "sha512-fHn8/9SNNsvTXhekJBCHZ24+ZsBHaisjPep7mipuAeWxTUdN6KTyfY9hpleKPv/VOlA1o4ENueQkNFhoFesftw==",
+      "version": "5.14.0",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/file-system-process/-/file-system-process-5.14.0.tgz",
+      "integrity": "sha512-zDkSEAUi5IsWqAqAwWtAN+AnuPr/6ZG0nrB5kLhT9i3P/TvODMB02DFVs3XgSQF+8i0QeAFkpfu78nhRb7RoNQ==",
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -3085,9 +3085,9 @@
       }
     },
     "node_modules/@lvce-editor/file-watcher-process": {
-      "version": "4.12.0",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/file-watcher-process/-/file-watcher-process-4.12.0.tgz",
-      "integrity": "sha512-3nLW4QWoH9eLpQ2bcKrawNxH7q2aLbdH0+E19kmlukOTM+HWmIj9dnJKr3zPiOKOnUjE/S0bZwB1gL+2Arbd4g==",
+      "version": "4.13.0",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/file-watcher-process/-/file-watcher-process-4.13.0.tgz",
+      "integrity": "sha512-2MGT1ycIek8pPSiu6CHSbRTtvLG8IOXN17ZbgiQbJvrbDrVck+GAGrPGYEbceZoaRImAWaMOQjjVVjZFn+ElTg==",
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -3103,9 +3103,9 @@
       }
     },
     "node_modules/@lvce-editor/ipc": {
-      "version": "16.10.0",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/ipc/-/ipc-16.10.0.tgz",
-      "integrity": "sha512-iL4D4ou4iSOvVu2S7/L20JHDavOYcA0o2y8HDQYdksBkK52Dlbt4U1f96DC2FMfKl/6uTBuZFNL8hCapYZMa6w==",
+      "version": "16.11.0",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/ipc/-/ipc-16.11.0.tgz",
+      "integrity": "sha512-+P1E4Oi1RF/UoJQba2v4Q3E/s6L6ubJOJ2u8jASG/KSijBf12OWKnIxwJBKQtyKXVnay5kE4HNMciqaNVrJZmg==",
       "license": "MIT",
       "dependencies": {
         "@lvce-editor/assert": "^1.5.1",
@@ -3421,40 +3421,40 @@
       }
     },
     "node_modules/@lvce-editor/rpc": {
-      "version": "6.16.0",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/rpc/-/rpc-6.16.0.tgz",
-      "integrity": "sha512-NK9k9/L3fWhwy3j3zrG0ffqHE+9SZ7DevvKcTkrrbgKAS3/L/pAJsTI9MuD8F+18oJEncjCmFTr26+CK3aPSgA==",
+      "version": "6.18.0",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/rpc/-/rpc-6.18.0.tgz",
+      "integrity": "sha512-c4AYWipYe3l0LGFJqqQQbToyspN09WaR7GieFuhDD0CDfGVZLbjMffJxxpUqoRbDIc0Brd4eXBJha0/6/4jAUw==",
       "license": "MIT",
       "dependencies": {
         "@lvce-editor/assert": "^1.5.1",
         "@lvce-editor/command": "^2.0.0",
-        "@lvce-editor/ipc": "^16.9.0",
-        "@lvce-editor/json-rpc": "^8.4.0",
+        "@lvce-editor/ipc": "^16.11.0",
+        "@lvce-editor/json-rpc": "^8.6.0",
         "@lvce-editor/verror": "^1.7.0"
       }
     },
     "node_modules/@lvce-editor/rpc-registry": {
-      "version": "9.48.0",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/rpc-registry/-/rpc-registry-9.48.0.tgz",
-      "integrity": "sha512-GHbf/Nzn2x30gk6cS600LVnbbPwUCPnjxtG9Kl0AHtUNx6SYeFKCfA/LftEUKg934TEG1WcvSkgo1vG3s0m9Bw==",
+      "version": "9.51.0",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/rpc-registry/-/rpc-registry-9.51.0.tgz",
+      "integrity": "sha512-N8HWyjINBTako+zUsFjJ8C8UBC1OUjXnwAC8AkAiZ8WDkRSJw/eQAS+tQxxCKnPYoo8YZ8Qf/q3W4Hjp9bfhAQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@lvce-editor/assert": "^1.5.1",
-        "@lvce-editor/constants": "^5.26.0",
+        "@lvce-editor/constants": "^5.27.0",
         "@lvce-editor/rpc": "^6.4.0"
       }
     },
     "node_modules/@lvce-editor/search-process": {
-      "version": "15.7.0",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/search-process/-/search-process-15.7.0.tgz",
-      "integrity": "sha512-eAyrQ8TakmyKXffDy0hDcsKVoZ6du44kos4XFeDnedfsd1znIBrsnF6mMplixMdL619Cd90kTXA739B7QMorRg==",
+      "version": "15.8.0",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/search-process/-/search-process-15.8.0.tgz",
+      "integrity": "sha512-zS8buRVqlu4DL34GKZsqvuF1nutIkeTfA/o/HDwWy6m6nnlQWOXBDCOHY3OH7qSr974CwstREI2wHTi3R3ycUw==",
       "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
         "execa": "^9.6.1",
-        "ws": "^8.21.1"
+        "ws": "^8.21.3"
       },
       "bin": {
         "search-process": "bin/searchProcess.js"
@@ -3467,14 +3467,14 @@
       }
     },
     "node_modules/@lvce-editor/server": {
-      "version": "0.100.3",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/server/-/server-0.100.3.tgz",
-      "integrity": "sha512-S2U82benzMvl1k1zXk//Y6yOEvhYQDFHa5I3zltADMG6AVb7XlZJsMFoccaJkJnIBmsVdVmwpk/5AC9xcFsdSQ==",
+      "version": "0.100.22",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/server/-/server-0.100.22.tgz",
+      "integrity": "sha512-hLezrJzBsRm225v3iVFI12P/7EBryWaD/M6IX+XmLkcGZCB41LluR5UHONx9uC3NFjoygZ5+YU2+LRDTdyQ/OA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@lvce-editor/shared-process": "0.100.3",
-        "@lvce-editor/static-server": "0.100.3"
+        "@lvce-editor/shared-process": "0.100.22",
+        "@lvce-editor/static-server": "0.100.22"
       },
       "bin": {
         "server": "bin/server.js"
@@ -3484,20 +3484,20 @@
       }
     },
     "node_modules/@lvce-editor/shared-process": {
-      "version": "0.100.3",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/shared-process/-/shared-process-0.100.3.tgz",
-      "integrity": "sha512-aNmMKkV+V3gvPz0U7hzyNNWuWYnB/MCJOaPk65cgjNafQnvc0uxmQMx1++v0JMvUsybroTKwvc4oQaUWf+13CA==",
+      "version": "0.100.22",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/shared-process/-/shared-process-0.100.22.tgz",
+      "integrity": "sha512-6fWwt8kf36v3VOibBRskUmjWGBuD72Xu6zvhCjcQtU4DKN5hKZ+9h8pn9nRxAEIwp7a2VsNAM43HqG50k+dQJg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@lvce-editor/assert": "1.9.0",
-        "@lvce-editor/extension-host-helper-process": "0.100.3",
-        "@lvce-editor/ipc": "16.10.0",
+        "@lvce-editor/extension-host-helper-process": "0.100.22",
+        "@lvce-editor/ipc": "16.11.0",
         "@lvce-editor/json-rpc": "8.6.0",
         "@lvce-editor/jsonc-parser": "1.5.0",
         "@lvce-editor/pretty-error": "2.0.0",
         "@lvce-editor/process-explorer": "3.14.0",
-        "@lvce-editor/rpc-registry": "9.48.0",
+        "@lvce-editor/rpc-registry": "9.51.0",
         "@lvce-editor/verror": "1.7.0",
         "is-object": "^1.0.2",
         "markdown-it": "^15.0.0",
@@ -3507,15 +3507,15 @@
         "node": ">=24"
       },
       "optionalDependencies": {
-        "@lvce-editor/embeds-process": "4.15.0",
-        "@lvce-editor/file-system-process": "5.12.0",
-        "@lvce-editor/file-watcher-process": "4.12.0",
+        "@lvce-editor/embeds-process": "4.16.0",
+        "@lvce-editor/file-system-process": "5.14.0",
+        "@lvce-editor/file-watcher-process": "4.13.0",
         "@lvce-editor/network-process": "5.2.0",
         "@lvce-editor/preload": "1.5.0",
         "@lvce-editor/preview-process": "11.0.0",
         "@lvce-editor/pty-host": "8.7.0",
-        "@lvce-editor/search-process": "15.7.0",
-        "@lvce-editor/typescript-compile-process": "5.8.0",
+        "@lvce-editor/search-process": "15.8.0",
+        "@lvce-editor/typescript-compile-process": "5.9.0",
         "open": "^11.0.0",
         "tail": "^2.2.6",
         "tmp-promise": "^3.0.3",
@@ -3523,9 +3523,9 @@
       }
     },
     "node_modules/@lvce-editor/static-server": {
-      "version": "0.100.3",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/static-server/-/static-server-0.100.3.tgz",
-      "integrity": "sha512-C3pMTwHvtPIbV3T856euh7Gq4PGgz89t09N9xfwkiZJqp5CGWhTtMeIgZIPAse2730TZIzJgLPRM9KVcp18kjw==",
+      "version": "0.100.22",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/static-server/-/static-server-0.100.22.tgz",
+      "integrity": "sha512-SZoz2xh86xpwMq2PlqJj1cagBso5+2EYJjo8g16lOuanSafyW+kjesx6Ak+QsJHcbEM6Upc5v/g81aExdhM86w==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -3576,9 +3576,9 @@
       "license": "MIT"
     },
     "node_modules/@lvce-editor/typescript-compile-process": {
-      "version": "5.8.0",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/typescript-compile-process/-/typescript-compile-process-5.8.0.tgz",
-      "integrity": "sha512-kJ/NDVYT/KirvB/qAo8f0rVDJKgaRyCrYZ5c5W8B2bQ4iQLnQ68FHJcIKypRa6vN7bfI544xfl7laqMOhZZ28w==",
+      "version": "5.9.0",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/typescript-compile-process/-/typescript-compile-process-5.9.0.tgz",
+      "integrity": "sha512-qYsKBc0FkVFshKpC88+/T3P41Xi5nx2Hb2y8Vq2DHr+ceGq7w7XTnVZBqWVe4vO7eZPLpyi3/UhdD8a8P7ADuQ==",
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -15372,9 +15372,9 @@
       }
     },
     "node_modules/ws": {
-      "version": "8.21.1",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.1.tgz",
-      "integrity": "sha512-+0NTnW77fFN/DjQi6k/Sq/Yvk4Sgajw7urW8V+asjXnRgDs9gyGkdb7EzgfhA4goXsRIZKE28fzIXBHEzhuiWw==",
+      "version": "8.21.3",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.3.tgz",
+      "integrity": "sha512-201TZ/kPWxoPr/OKWjquZR1SWKXcvxdH+e1xrx89b3YbmzLMFCLfnaG1HFIgWzJOEWZ7MvpK++odZufgYR50Rw==",
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"
@@ -15575,7 +15575,7 @@
       "license": "MIT",
       "devDependencies": {
         "@lvce-editor/package-extension": "^3.7.0",
-        "@lvce-editor/server": "^0.100.3",
+        "@lvce-editor/server": "^0.100.22",
         "esbuild": "^0.28.2"
       }
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -2871,9 +2871,9 @@
       "optional": true
     },
     "node_modules/@lvce-editor/api": {
-      "version": "9.16.0",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/api/-/api-9.16.0.tgz",
-      "integrity": "sha512-ygs0QIPbTWmEwQVKuQbhpp3QM/eYLCaI8PXASWO29cOJKqyWo+SlNA16pshwGAWrjbEkSbrByA4Himodr4JGEw==",
+      "version": "9.16.1",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/api/-/api-9.16.1.tgz",
+      "integrity": "sha512-9ijFWJF7Hc5GpBjVdDspiZYC5ojMWZaLTY/2nEPOuF0+7jaMiFdakuuZxcNS1HHooIx4xCxPCUHECuIZFPUPnA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -15592,7 +15592,7 @@
       "license": "MIT",
       "devDependencies": {
         "@jest/globals": "^30.4.1",
-        "@lvce-editor/api": "^9.16.0",
+        "@lvce-editor/api": "^9.16.1",
         "@lvce-editor/virtual-dom-worker": "^11.12.2"
       }
     },

--- a/packages/build/package.json
+++ b/packages/build/package.json
@@ -10,7 +10,7 @@
   "license": "MIT",
   "devDependencies": {
     "@lvce-editor/package-extension": "^3.7.0",
-    "@lvce-editor/server": "^0.100.3",
+    "@lvce-editor/server": "^0.100.22",
     "esbuild": "^0.28.2"
   }
 }

--- a/packages/e2e/src/media-preview-status-bar-items.ts
+++ b/packages/e2e/src/media-preview-status-bar-items.ts
@@ -16,14 +16,25 @@ const waitForExpectation = async (assertion: () => Promise<void>): Promise<void>
 
 export const test: Test = async ({ expect, Locator, Main, Settings }) => {
   await Settings.update({ 'statusBar.itemsVisible': true })
-  const uri = import.meta.resolve('../files/file.png')
-  await Main.openUri(uri)
+  const firstUri = import.meta.resolve('../files/file.png')
+  const secondUri = import.meta.resolve('../files/sample.jpg')
+  await Main.openUris([firstUri, secondUri])
 
   const dimensions = Locator('.StatusBarItem[name="media-preview-dimensions"]')
   const size = Locator('.StatusBarItem[name="media-preview-size"]')
+  const tabs = Locator('.MainTab')
+  await waitForExpectation(() => expect(tabs).toHaveCount(2))
+  await waitForExpectation(() => expect(dimensions).toHaveCount(1))
+  await waitForExpectation(() => expect(size).toHaveCount(1))
   await waitForExpectation(() => expect(dimensions).toBeVisible())
-  await waitForExpectation(() => expect(dimensions).toHaveText('256 × 256'))
   await waitForExpectation(() => expect(size).toBeVisible())
+  await waitForExpectation(() => expect(size).toHaveText('100 kB'))
+
+  await Main.selectTab(0, 0)
+
+  await waitForExpectation(() => expect(dimensions).toHaveCount(1))
+  await waitForExpectation(() => expect(size).toHaveCount(1))
+  await waitForExpectation(() => expect(dimensions).toHaveText('256 × 256'))
   await waitForExpectation(() => expect(size).toHaveText('873 B'))
 
   await Main.closeAllEditors()

--- a/packages/extension/package.json
+++ b/packages/extension/package.json
@@ -33,7 +33,7 @@
   },
   "devDependencies": {
     "@jest/globals": "^30.4.1",
-    "@lvce-editor/api": "^9.16.0",
+    "@lvce-editor/api": "^9.16.1",
     "@lvce-editor/virtual-dom-worker": "^11.12.2"
   }
 }

--- a/packages/extension/package.json
+++ b/packages/extension/package.json
@@ -33,7 +33,7 @@
   },
   "devDependencies": {
     "@jest/globals": "^30.4.1",
-    "@lvce-editor/api": "^9.16.1",
+    "@lvce-editor/api": "^9.16.2",
     "@lvce-editor/virtual-dom-worker": "^11.12.2"
   }
 }


### PR DESCRIPTION
Bundle the fixed extension API so image dimensions and file size come only from the active media-preview tab. Extend the status bar e2e coverage to open two image tabs and verify the single item pair follows tab focus.