### PR TITLE
fix: show file size for absolute paths

### DIFF
--- a/packages/extension/src/parts/GetFileSize/GetFileSize.ts
+++ b/packages/extension/src/parts/GetFileSize/GetFileSize.ts
@@ -2,9 +2,21 @@ import { readFileAsBlob } from '@lvce-editor/api'
 
 type ReadFileAsBlob = (uri: string) => Promise<Blob>
 
+const windowsAbsolutePathPattern = /^[a-z]:[\\/]/i
+
+const toFileUri = (uri: string): string => {
+  if (uri.startsWith('/')) {
+    return `file://${uri}`
+  }
+  if (windowsAbsolutePathPattern.test(uri)) {
+    return `file:///${uri.replaceAll('\\', '/')}`
+  }
+  return uri
+}
+
 export const getFileSizeWithDependency = async (uri: string, readBlob: ReadFileAsBlob): Promise<number> => {
   try {
-    const blob = await readBlob(uri)
+    const blob = await readBlob(toFileUri(uri))
     return blob.size
   } catch {
     return 0

--- a/packages/extension/test/GetFileSize.test.ts
+++ b/packages/extension/test/GetFileSize.test.ts
@@ -14,6 +14,20 @@ test('returns the blob byte size', async () => {
   expect(readFileAsBlob).toHaveBeenCalledWith('file:///workspace/image.png')
 })
 
+test('returns the blob byte size for an absolute disk path', async () => {
+  readFileAsBlob.mockResolvedValue(new Blob(['hello']))
+
+  await expect(getFileSizeWithDependency('/workspace/image.png', readFileAsBlob)).resolves.toBe(5)
+  expect(readFileAsBlob).toHaveBeenCalledWith('file:///workspace/image.png')
+})
+
+test('returns the blob byte size for an absolute Windows disk path', async () => {
+  readFileAsBlob.mockResolvedValue(new Blob(['hello']))
+
+  await expect(getFileSizeWithDependency('C:\\workspace\\image.png', readFileAsBlob)).resolves.toBe(5)
+  expect(readFileAsBlob).toHaveBeenCalledWith('file:///C:/workspace/image.png')
+})
+
 test('returns zero when the image cannot be read', async () => {
   readFileAsBlob.mockRejectedValue(new Error('File not found'))
 


### PR DESCRIPTION
Normalize absolute POSIX and Windows disk paths to file URIs before reading image blobs, so media preview can report real file sizes in the installed editor.