### PR TITLE
fix: enable keyboard image navigation for local files

### DIFF
--- a/packages/extension/src/parts/GetFileSize/GetFileSize.ts
+++ b/packages/extension/src/parts/GetFileSize/GetFileSize.ts
@@ -1,18 +1,7 @@
 import { readFileAsBlob } from '@lvce-editor/api'
+import { toFileUri } from '../ToFileUri/ToFileUri.ts'
 
 type ReadFileAsBlob = (uri: string) => Promise<Blob>
-
-const windowsAbsolutePathPattern = /^[a-z]:[\\/]/i
-
-const toFileUri = (uri: string): string => {
-  if (uri.startsWith('/')) {
-    return `file://${uri}`
-  }
-  if (windowsAbsolutePathPattern.test(uri)) {
-    return `file:///${uri.replaceAll('\\', '/')}`
-  }
-  return uri
-}
 
 export const getFileSizeWithDependency = async (uri: string, readBlob: ReadFileAsBlob): Promise<number> => {
   try {

--- a/packages/extension/src/parts/GetSiblingImageUris/GetSiblingImageUris.ts
+++ b/packages/extension/src/parts/GetSiblingImageUris/GetSiblingImageUris.ts
@@ -1,4 +1,5 @@
 import { readDirWithFileTypes, type FileSystemDirent } from '@lvce-editor/api'
+import { toFileUri } from '../ToFileUri/ToFileUri.ts'
 
 // cspell:ignore apng jfif
 
@@ -97,7 +98,7 @@ export const getSiblingImageUrisWithDependency = async (
   if (!parts) {
     return []
   }
-  const entries = await readDirectory(parts.parentUri)
+  const entries = await readDirectory(toFileUri(parts.parentUri))
   const imageNames = entries
     .map((entry) => entry.name)
     .filter(isImage)

--- a/packages/extension/src/parts/ToFileUri/ToFileUri.ts
+++ b/packages/extension/src/parts/ToFileUri/ToFileUri.ts
@@ -1,0 +1,11 @@
+const windowsAbsolutePathPattern = /^[a-z]:[\\/]/i
+
+export const toFileUri = (uri: string): string => {
+  if (uri.startsWith('/')) {
+    return `file://${uri}`
+  }
+  if (windowsAbsolutePathPattern.test(uri)) {
+    return `file:///${uri.replaceAll('\\', '/')}`
+  }
+  return uri
+}

--- a/packages/extension/test/GetSiblingImageUris.test.ts
+++ b/packages/extension/test/GetSiblingImageUris.test.ts
@@ -17,7 +17,7 @@ test('returns naturally sorted image siblings for a path', async () => {
     '/workspace/image2.JPG',
     '/workspace/image10.png',
   ])
-  expect(readDirectory).toHaveBeenCalledWith('/workspace/')
+  expect(readDirectory).toHaveBeenCalledWith('file:///workspace/')
 })
 
 test('preserves encoded file uris', async () => {
@@ -37,7 +37,7 @@ test('supports windows paths', async () => {
     'C:\\pictures\\a.png',
     'C:\\pictures\\b.gif',
   ])
-  expect(readDirectory).toHaveBeenCalledWith('C:\\pictures\\')
+  expect(readDirectory).toHaveBeenCalledWith('file:///C:/pictures/')
 })
 
 test('returns no siblings when the uri has no parent', async () => {


### PR DESCRIPTION
Convert absolute local directory paths to file URIs before sibling discovery.

Adds POSIX and Windows coverage and reuses the same conversion as file-size reads.