### PR TITLE
fix: contain tall image previews

### DIFF
--- a/packages/e2e/src/media-preview-tall-image-fit.ts
+++ b/packages/e2e/src/media-preview-tall-image-fit.ts
@@ -1,0 +1,20 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+const tallSvg = `<svg width="100" height="1000" viewBox="0 0 100 1000" xmlns="http://www.w3.org/2000/svg">
+  <rect width="100" height="1000" fill="red" />
+</svg>`
+
+export const name = 'media-preview-tall-image-fit'
+
+export const test: Test = async ({ expect, FileSystem, Locator, Main }) => {
+  const tmpDir = await FileSystem.getTmpDir()
+  const uri = `${tmpDir}/tall.svg`
+  await FileSystem.setFiles([{ content: tallSvg, uri }])
+  await Main.openUri(uri)
+
+  const image = Locator('.MediaPreviewImage')
+  await expect(image).toHaveJSProperty('naturalWidth', 100)
+  await expect(image).toHaveJSProperty('naturalHeight', 1000)
+  await expect(image).toHaveJSProperty('offsetWidth', 64)
+  await expect(image).toHaveJSProperty('offsetHeight', 642)
+}

--- a/packages/extension/media/index.css
+++ b/packages/extension/media/index.css
@@ -21,6 +21,8 @@
 }
 
 .MediaPreviewImage {
+  width: auto;
+  height: auto;
   max-width: 100%;
   max-height: 100%;
   user-select: none;
@@ -28,7 +30,12 @@
 }
 
 .MediaPreviewImageWrapper {
+  width: 100%;
+  height: 100%;
   contain: content;
+  display: flex;
+  align-items: center;
+  justify-content: center;
 }
 
 .MediaPreviewDragging {


### PR DESCRIPTION
Size the image wrapper to the preview area and let image dimensions resolve automatically before applying the maximum bounds. This keeps tall images fully visible without changing their aspect ratio.

Adds an end-to-end regression for a 1:10 image that asserts both rendered dimensions.