### PR TITLE
fix: remove closed media preview status items

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2871,9 +2871,9 @@
       "optional": true
     },
     "node_modules/@lvce-editor/api": {
-      "version": "9.16.2",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/api/-/api-9.16.2.tgz",
-      "integrity": "sha512-7x7QXFcZwzAef938iS9WJ0mCvJDbkNcOViMkNPlYXQ7iW2P9ll6T1ERLhIl5h7TeYjZYb5+oqwxD/cOFsGeNkw==",
+      "version": "9.17.1",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/api/-/api-9.17.1.tgz",
+      "integrity": "sha512-nGhKPCN0e4K44QL/867FzS4cuU9amzHvKNq7++77eCCABKWF0XsXXceBIopKeDNyobzjTKE6cqzheSDjst9ZRg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -15604,7 +15604,7 @@
       "license": "MIT",
       "devDependencies": {
         "@jest/globals": "^30.4.1",
-        "@lvce-editor/api": "^9.16.2",
+        "@lvce-editor/api": "^9.17.1",
         "@lvce-editor/dom-matrix": "0.0.0-dev",
         "@lvce-editor/virtual-dom-worker": "^11.12.2"
       }

--- a/packages/extension/package.json
+++ b/packages/extension/package.json
@@ -33,7 +33,7 @@
   },
   "devDependencies": {
     "@jest/globals": "^30.4.1",
-    "@lvce-editor/api": "^9.16.2",
+    "@lvce-editor/api": "^9.17.1",
     "@lvce-editor/dom-matrix": "0.0.0-dev",
     "@lvce-editor/virtual-dom-worker": "^11.12.2"
   }


### PR DESCRIPTION
Update the media preview extension to the API release that waits for status bar provider removal before view disposal completes.

This makes the existing media preview close regression reliably remove image dimensions and file size from the status bar.