### PR TITLE
fix: make media preview wheel listener passive

### DIFF
--- a/packages/extension/extension.json
+++ b/packages/extension/extension.json
@@ -71,7 +71,7 @@
             "event.currentTarget.clientHeight",
             "event.currentTarget.ownerDocument.defaultView.devicePixelRatio"
           ],
-          "preventDefault": true
+          "passive": true
         }
       ],
       "id": "builtin.media-preview",

--- a/packages/extension/src/parts/MediaPreviewView/MediaPreviewView.ts
+++ b/packages/extension/src/parts/MediaPreviewView/MediaPreviewView.ts
@@ -59,7 +59,7 @@ export const view: View<MediaPreviewViewInstance> = {
         'event.currentTarget.clientHeight',
         'event.currentTarget.ownerDocument.defaultView.devicePixelRatio',
       ],
-      preventDefault: true,
+      passive: true,
     },
   ],
   id: viewId,

--- a/packages/extension/test/MediaPreviewView.test.ts
+++ b/packages/extension/test/MediaPreviewView.test.ts
@@ -25,7 +25,8 @@ test('contributes a virtual dom media preview view', () => {
     'handleMediaPreviewImageError',
     'event.currentTarget.dataset.sourceUrl',
   ])
-  expect(view.eventListeners?.find((listener) => listener.name === 'handleMediaPreviewWheel')?.params).toEqual([
+  const wheelListener = view.eventListeners?.find((listener) => listener.name === 'handleMediaPreviewWheel')
+  expect(wheelListener?.params).toEqual([
     'handleMediaPreviewWheel',
     'event.deltaY',
     'event.deltaMode',
@@ -33,6 +34,8 @@ test('contributes a virtual dom media preview view', () => {
     'event.currentTarget.clientHeight',
     'event.currentTarget.ownerDocument.defaultView.devicePixelRatio',
   ])
+  expect(wheelListener?.passive).toBe(true)
+  expect(wheelListener?.preventDefault).toBeUndefined()
   expect(view.eventListeners?.find((listener) => listener.name === 'handleMediaPreviewKeyDown')?.params).toEqual([
     'handleMediaPreviewKeyDown',
     'event.key',


### PR DESCRIPTION
Marks the media preview wheel listener as passive and stops requesting preventDefault, removing Chromium's scroll-blocking event listener warning while preserving wheel zoom handling.