### PR TITLE
fix: show missing image message for disk paths

### DIFF
--- a/packages/e2e/src/media-preview-error-removes-image.ts
+++ b/packages/e2e/src/media-preview-error-removes-image.ts
@@ -8,8 +8,10 @@ export const test: Test = async ({ expect, FileSystem, Locator, Main }) => {
   await FileSystem.writeFile(uri, 'not an image')
   await Main.openUri(uri)
 
+  const error = Locator('.MediaPreviewError')
   const image = Locator('.MediaPreviewImage')
   const content = Locator('.MediaPreviewContent')
+  await expect(error).toBeVisible()
   await expect(image).toHaveCount(0)
   await expect(content).toHaveCount(0)
 }

--- a/packages/e2e/src/media-preview-missing-absolute-path-error.ts
+++ b/packages/e2e/src/media-preview-missing-absolute-path-error.ts
@@ -2,8 +2,13 @@ import type { Test } from '@lvce-editor/test-with-playwright'
 
 export const name = 'media-preview-missing-absolute-path-error'
 
-export const test: Test = async ({ expect, Locator, Main }) => {
-  await Main.openUri('/__lvce_media_preview_missing__.svg')
+const toAbsolutePath = (fileUri: string): string => {
+  return /^file:\/\/\/[a-z]:/i.test(fileUri) ? fileUri.slice('file:///'.length) : fileUri.slice('file://'.length)
+}
+
+export const test: Test = async ({ expect, FileSystem, Locator, Main }) => {
+  const tmpDir = await FileSystem.getTmpDir({ scheme: 'file' })
+  await Main.openUri(`${toAbsolutePath(tmpDir)}/missing.svg`)
 
   const error = Locator('.MediaPreviewError')
   const openInTextEditor = Locator('.MediaPreviewOpenInTextEditor')

--- a/packages/e2e/src/media-preview-missing-absolute-path-error.ts
+++ b/packages/e2e/src/media-preview-missing-absolute-path-error.ts
@@ -1,0 +1,13 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'media-preview-missing-absolute-path-error'
+
+export const test: Test = async ({ expect, Locator, Main }) => {
+  await Main.openUri('/__lvce_media_preview_missing__.svg')
+
+  const error = Locator('.MediaPreviewError')
+  const openInTextEditor = Locator('.MediaPreviewOpenInTextEditor')
+  await expect(error).toBeVisible()
+  await expect(error).toHaveText('Image could not be found')
+  await expect(openInTextEditor).toHaveCount(0)
+}

--- a/packages/extension/src/parts/MediaPreviewViewInstance/MediaPreviewViewInstance.ts
+++ b/packages/extension/src/parts/MediaPreviewViewInstance/MediaPreviewViewInstance.ts
@@ -13,6 +13,7 @@ import * as MediaPreview from '../MediaPreview/MediaPreview.ts'
 import { render } from '../RenderMediaPreview/RenderMediaPreview.ts'
 import { renderStatusBarItems } from '../RenderStatusBarItems/RenderStatusBarItems.ts'
 import { shouldUpgradeImage } from '../ShouldUpgradeImage/ShouldUpgradeImage.ts'
+import { toFileUri } from '../ToFileUri/ToFileUri.ts'
 
 export interface MediaPreviewState {
   readonly canOpenAsText: boolean
@@ -124,7 +125,7 @@ const getImageErrorMessage = async (uri: string, exists: MediaPreviewApi['exists
     return imageCouldNotBeLoaded
   }
   try {
-    return (await exists(uri)) ? imageCouldNotBeLoaded : imageCouldNotBeFound
+    return (await exists(toFileUri(uri))) ? imageCouldNotBeLoaded : imageCouldNotBeFound
   } catch {
     return imageCouldNotBeLoaded
   }

--- a/packages/extension/test/MediaPreviewViewInstance.test.ts
+++ b/packages/extension/test/MediaPreviewViewInstance.test.ts
@@ -141,7 +141,7 @@ test('renders a load error when the image URL cannot be read but the file exists
 
   const instance = await createInstanceWithApi(context, api)
 
-  expect(api.exists).toHaveBeenCalledWith('/workspace/image.png')
+  expect(api.exists).toHaveBeenCalledWith('file:///workspace/image.png')
   expect(instance.render().some((node) => node.text === 'Image could not be loaded')).toBe(true)
 })
 
@@ -228,7 +228,7 @@ test('forwards pointer and image events to the media preview api', async () => {
 
   await instance.handleMediaPreviewImageError('')
   expect(api.handleError).toHaveBeenCalledWith(7)
-  expect(api.exists).toHaveBeenCalledWith('/workspace/image.png')
+  expect(api.exists).toHaveBeenCalledWith('file:///workspace/image.png')
   expect(instance.render().some((node) => node.text === 'Image could not be loaded')).toBe(true)
 })
 


### PR DESCRIPTION
Normalize absolute disk paths before checking whether a failed media preview still exists. Missing images now show the not-found message and hide the text-editor fallback, with focused end-to-end regression coverage.