### PR TITLE
fix: open audio files from custom file systems

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2871,9 +2871,9 @@
       "optional": true
     },
     "node_modules/@lvce-editor/api": {
-      "version": "9.27.0",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/api/-/api-9.27.0.tgz",
-      "integrity": "sha512-uCzPYgs/TWjirrMsNx/XiO3zTsyZILBFXzYvmP5+reHQNXBZV8ZlYsoKKoXfLd7LoHQu0q2pGz7MNxwpORxEnQ==",
+      "version": "9.27.1",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/api/-/api-9.27.1.tgz",
+      "integrity": "sha512-vga6hXdyTwuRFBHG6fnCC/uDgnFFzc1VWq8BdT8FCSoQJoE88rVxf/qLTHgjPOA5Ru8AShsPSzxzakfD5jB5bA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -15609,7 +15609,7 @@
       "license": "MIT",
       "devDependencies": {
         "@jest/globals": "^30.4.1",
-        "@lvce-editor/api": "^9.23.0",
+        "@lvce-editor/api": "^9.27.1",
         "@lvce-editor/dom-matrix": "0.0.0-dev",
         "@lvce-editor/virtual-dom-worker": "^11.14.0"
       }

--- a/packages/extension/package.json
+++ b/packages/extension/package.json
@@ -33,7 +33,7 @@
   },
   "devDependencies": {
     "@jest/globals": "^30.4.1",
-    "@lvce-editor/api": "^9.23.0",
+    "@lvce-editor/api": "^9.27.1",
     "@lvce-editor/dom-matrix": "0.0.0-dev",
     "@lvce-editor/virtual-dom-worker": "^11.14.0"
   }


### PR DESCRIPTION
Update the bundled extension API so custom-scheme media URIs resolve to blob URLs instead of invalid `/remote` disk paths.