### PR TITLE
fix: store image extensions in preview state

### DIFF
--- a/packages/extension/src/parts/GetSiblingImageUris/GetSiblingImageUris.ts
+++ b/packages/extension/src/parts/GetSiblingImageUris/GetSiblingImageUris.ts
@@ -1,8 +1,6 @@
 import { readDirWithFileTypes, type FileSystemDirent } from '@lvce-editor/api'
 import { toFileUri } from '../ToFileUri/ToFileUri.ts'
 
-// cspell:ignore apng jfif
-
 type ReadDirWithFileTypes = (uri: string) => Promise<readonly FileSystemDirent[]>
 
 interface UriParts {
@@ -10,25 +8,6 @@ interface UriParts {
   readonly join: (name: string) => string
   readonly parentUri: string
 }
-
-const imageExtensions = new Set([
-  '.apng',
-  '.avif',
-  '.bmp',
-  '.gif',
-  '.heic',
-  '.heif',
-  '.ico',
-  '.jpe',
-  '.jfif',
-  '.jpeg',
-  '.jpg',
-  '.png',
-  '.svg',
-  '.tif',
-  '.tiff',
-  '.webp',
-])
 
 const uriSchemePattern = /^[a-z][a-z\d+.-]*:\/\//i
 
@@ -80,9 +59,9 @@ const getUriParts = (uri: string): UriParts | undefined => {
   return uriSchemePattern.test(uri) ? getUrlParts(uri) : getPathParts(uri)
 }
 
-const isImage = (name: string): boolean => {
+const isImage = (name: string, imageExtensions: readonly string[]): boolean => {
   const dotIndex = name.lastIndexOf('.')
-  return dotIndex !== -1 && imageExtensions.has(name.slice(dotIndex).toLowerCase())
+  return dotIndex !== -1 && imageExtensions.includes(name.slice(dotIndex).toLowerCase())
 }
 
 const compareNames = (a: string, b: string): number => {
@@ -91,6 +70,7 @@ const compareNames = (a: string, b: string): number => {
 
 export const getSiblingImageUrisWithDependency = async (
   uri: string,
+  imageExtensions: readonly string[],
   readDirectory: ReadDirWithFileTypes,
 ): Promise<readonly string[]> => {
   const parts = getUriParts(uri)
@@ -100,7 +80,7 @@ export const getSiblingImageUrisWithDependency = async (
   const entries = await readDirectory(toFileUri(parts.parentUri))
   const imageNames = entries
     .map((entry) => entry.name)
-    .filter(isImage)
+    .filter((name) => isImage(name, imageExtensions))
     .toSorted(compareNames)
   if (!imageNames.includes(parts.baseName)) {
     return []
@@ -108,6 +88,6 @@ export const getSiblingImageUrisWithDependency = async (
   return imageNames.map(parts.join)
 }
 
-export const getSiblingImageUris = (uri: string): Promise<readonly string[]> => {
-  return getSiblingImageUrisWithDependency(uri, readDirWithFileTypes)
+export const getSiblingImageUris = (uri: string, imageExtensions: readonly string[]): Promise<readonly string[]> => {
+  return getSiblingImageUrisWithDependency(uri, imageExtensions, readDirWithFileTypes)
 }

--- a/packages/extension/src/parts/MediaPreviewViewInstance/MediaPreviewViewInstance.ts
+++ b/packages/extension/src/parts/MediaPreviewViewInstance/MediaPreviewViewInstance.ts
@@ -15,6 +15,8 @@ import { renderStatusBarItems } from '../RenderStatusBarItems/RenderStatusBarIte
 import { shouldUpgradeImage } from '../ShouldUpgradeImage/ShouldUpgradeImage.ts'
 import { toFileUri } from '../ToFileUri/ToFileUri.ts'
 
+// cspell:ignore apng jfif
+
 export interface MediaPreviewState {
   readonly canOpenAsText: boolean
   readonly domMatrixString: string
@@ -22,6 +24,7 @@ export interface MediaPreviewState {
   readonly errorMessage: string
   readonly fileSize: number
   readonly height: number
+  readonly imageExtensions: readonly string[]
   readonly isFullResolution: boolean
   readonly pointerDown: boolean
   readonly scale: number
@@ -64,7 +67,7 @@ interface MediaPreviewApi {
   readonly exists: (uri: string) => Promise<boolean>
   readonly getFileSize: (uri: string) => Promise<number>
   readonly getFullResolutionUrl: (uri: string) => Promise<ImageSource>
-  readonly getSiblingImageUris: (uri: string) => Promise<readonly string[]>
+  readonly getSiblingImageUris: (uri: string, imageExtensions: readonly string[]) => Promise<readonly string[]>
   readonly getState: (id: number) => Pick<MediaPreviewState, 'domMatrixString' | 'error' | 'pointerDown' | 'scale'>
   readonly getUrl: (uri: string) => Promise<ImageSource>
   readonly handleError: (id: number) => Partial<MediaPreviewState>
@@ -166,6 +169,24 @@ export const createInstanceWithApi = async (
     error,
     errorMessage,
     fileSize,
+    imageExtensions: [
+      '.apng',
+      '.avif',
+      '.bmp',
+      '.gif',
+      '.heic',
+      '.heif',
+      '.ico',
+      '.jpe',
+      '.jfif',
+      '.jpeg',
+      '.jpg',
+      '.png',
+      '.svg',
+      '.tif',
+      '.tiff',
+      '.webp',
+    ],
   }
   let disposed = false
   let generation = 0
@@ -293,8 +314,9 @@ export const createInstanceWithApi = async (
   }
 
   const loadSiblingImageUris = async (): Promise<readonly string[]> => {
+    const { imageExtensions } = state
     try {
-      return await api.getSiblingImageUris(uri)
+      return await api.getSiblingImageUris(uri, imageExtensions)
     } catch {
       return []
     }

--- a/packages/extension/test/GetSiblingImageUris.test.ts
+++ b/packages/extension/test/GetSiblingImageUris.test.ts
@@ -4,6 +4,8 @@ import { getSiblingImageUrisWithDependency } from '../src/parts/GetSiblingImageU
 
 const file = (name: string): FileSystemDirent => ({ name, type: 7 })
 
+const imageExtensions = ['.gif', '.jpg', '.png', '.svg', '.webp']
+
 test('returns naturally sorted image siblings for a path', async () => {
   const readDirectory = jest.fn(async (_uri: string) => [
     file('image10.png'),
@@ -12,7 +14,7 @@ test('returns naturally sorted image siblings for a path', async () => {
     file('image1.svg'),
   ])
 
-  await expect(getSiblingImageUrisWithDependency('/workspace/image2.JPG', readDirectory)).resolves.toEqual([
+  await expect(getSiblingImageUrisWithDependency('/workspace/image2.JPG', imageExtensions, readDirectory)).resolves.toEqual([
     '/workspace/image1.svg',
     '/workspace/image2.JPG',
     '/workspace/image10.png',
@@ -23,17 +25,16 @@ test('returns naturally sorted image siblings for a path', async () => {
 test('preserves encoded file uris', async () => {
   const readDirectory = jest.fn(async (_uri: string) => [file('first image.png'), file('second # image.webp')])
 
-  await expect(getSiblingImageUrisWithDependency('file:///pictures/first%20image.png', readDirectory)).resolves.toEqual([
-    'file:///pictures/first%20image.png',
-    'file:///pictures/second%20%23%20image.webp',
-  ])
+  await expect(
+    getSiblingImageUrisWithDependency('file:///pictures/first%20image.png', imageExtensions, readDirectory),
+  ).resolves.toEqual(['file:///pictures/first%20image.png', 'file:///pictures/second%20%23%20image.webp'])
   expect(readDirectory).toHaveBeenCalledWith('file:///pictures/')
 })
 
 test('supports windows paths', async () => {
   const readDirectory = jest.fn(async (_uri: string) => [file('a.png'), file('b.gif')])
 
-  await expect(getSiblingImageUrisWithDependency('C:\\pictures\\b.gif', readDirectory)).resolves.toEqual([
+  await expect(getSiblingImageUrisWithDependency('C:\\pictures\\b.gif', imageExtensions, readDirectory)).resolves.toEqual([
     'C:\\pictures\\a.png',
     'C:\\pictures\\b.gif',
   ])
@@ -43,21 +44,28 @@ test('supports windows paths', async () => {
 test('returns no siblings when the uri has no parent', async () => {
   const readDirectory = jest.fn(async (_uri: string) => [file('image.png')])
 
-  await expect(getSiblingImageUrisWithDependency('image.png', readDirectory)).resolves.toEqual([])
+  await expect(getSiblingImageUrisWithDependency('image.png', imageExtensions, readDirectory)).resolves.toEqual([])
   expect(readDirectory).not.toHaveBeenCalled()
 })
 
 test('returns no siblings when the current image is absent', async () => {
   const readDirectory = jest.fn(async (_uri: string) => [file('other.png')])
 
-  await expect(getSiblingImageUrisWithDependency('/workspace/image.png', readDirectory)).resolves.toEqual([])
+  await expect(getSiblingImageUrisWithDependency('/workspace/image.png', imageExtensions, readDirectory)).resolves.toEqual([])
 })
 
 test('handles malformed uri encoding', async () => {
   const readDirectory = jest.fn(async (_uri: string) => [file('%image.png'), file('other.png')])
 
-  await expect(getSiblingImageUrisWithDependency('file:///pictures/%image.png', readDirectory)).resolves.toEqual([
-    'file:///pictures/%25image.png',
-    'file:///pictures/other.png',
+  await expect(getSiblingImageUrisWithDependency('file:///pictures/%image.png', imageExtensions, readDirectory)).resolves.toEqual(
+    ['file:///pictures/%25image.png', 'file:///pictures/other.png'],
+  )
+})
+
+test('uses the provided image extensions', async () => {
+  const readDirectory = jest.fn(async (_uri: string) => [file('image.custom'), file('other.png')])
+
+  await expect(getSiblingImageUrisWithDependency('/workspace/image.custom', ['.custom'], readDirectory)).resolves.toEqual([
+    '/workspace/image.custom',
   ])
 })

--- a/packages/extension/test/MediaPreviewViewInstance.test.ts
+++ b/packages/extension/test/MediaPreviewViewInstance.test.ts
@@ -35,7 +35,7 @@ const createApi = (): MockMediaPreviewApi => {
     exists: jest.fn(async (_uri: string) => true),
     getFileSize: jest.fn(async (_uri: string) => 512_596),
     getFullResolutionUrl: jest.fn(async (_uri: string) => source('blob:https://example.com/full-id')),
-    getSiblingImageUris: jest.fn(async (uri: string) => [uri]),
+    getSiblingImageUris: jest.fn(async (uri: string, _imageExtensions: readonly string[]) => [uri]),
     getState: jest.fn((_id: number) => initialState),
     getUrl: jest.fn(async (_uri: string) => source('blob:https://example.com/image-id')),
     handleError: jest.fn((_id: number) => ({ ...initialState, error: true })),
@@ -91,7 +91,7 @@ test('navigates to the next and previous image and resets the preview state', as
   await instance.handleMediaPreviewKeyDown('ArrowRight')
 
   expect(api.getSiblingImageUris).toHaveBeenCalledTimes(1)
-  expect(api.getSiblingImageUris).toHaveBeenCalledWith('/workspace/image2.png')
+  expect(api.getSiblingImageUris).toHaveBeenCalledWith('/workspace/image2.png', expect.arrayContaining(['.png', '.svg', '.webp']))
   expect(api.create).toHaveBeenCalledTimes(2)
   expect(api.getUrl).toHaveBeenLastCalledWith('/workspace/image10.png')
   expect(instance.render().some((node) => node.src === 'blob:/workspace/image10.png')).toBe(true)

--- a/packages/extension/test/RenderMediaPreview.test.ts
+++ b/packages/extension/test/RenderMediaPreview.test.ts
@@ -10,6 +10,7 @@ const state = {
   errorMessage: '',
   fileSize: 873,
   height: 1,
+  imageExtensions: [],
   isFullResolution: true,
   pointerDown: false,
   scale: 1,

--- a/packages/extension/test/RenderStatusBarItems.test.ts
+++ b/packages/extension/test/RenderStatusBarItems.test.ts
@@ -10,6 +10,7 @@ test('renders image metadata as two status bar items', () => {
       errorMessage: '',
       fileSize: 873,
       height: 480,
+      imageExtensions: [],
       isFullResolution: true,
       pointerDown: false,
       scale: 1,


### PR DESCRIPTION
Store supported image extensions in media preview instance state and pass them into sibling discovery.

Add regression coverage proving supplied extensions control sibling filtering.