### PR TITLE
fix: compute Firefox detection lazily

### DIFF
--- a/packages/extension/src/parts/Create/Create.ts
+++ b/packages/extension/src/parts/Create/Create.ts
@@ -1,5 +1,6 @@
 import * as DomMatrix from '@lvce-editor/dom-matrix'
 import type { WebView } from '../WebView/WebView.ts'
+import * as IsFirefox from '../IsFirefox/IsFirefox.ts'
 import * as PreviewStates from '../WebViewStates/WebViewStates.ts'
 
 export const create = (id: number): WebView => {
@@ -7,6 +8,7 @@ export const create = (id: number): WebView => {
   const preview: WebView = {
     domMatrix: DomMatrix.create(),
     error: false,
+    isFirefox: IsFirefox.getIsFirefox(),
     maxZoom: 2 ** 15, // max value that doesn't result in degradation
     minZoom: 0.1,
     pointerDown: false,

--- a/packages/extension/src/parts/HandleWheel/HandleWheel.ts
+++ b/packages/extension/src/parts/HandleWheel/HandleWheel.ts
@@ -1,7 +1,6 @@
 import * as DomMatrix from '@lvce-editor/dom-matrix'
 import type { WebView } from '../WebView/WebView.ts'
 import * as GetCurrentZoomFactor from '../GetCurrentZoomFactor/GetCurrentZoomFactor.ts'
-import * as IsFirefox from '../IsFirefox/IsFirefox.ts'
 import * as WebViewStates from '../WebViewStates/WebViewStates.ts'
 import * as WheelEvent from '../WheelEvent/WheelEvent.ts'
 
@@ -10,10 +9,10 @@ export const handleWheel = (id: number, eventX: number, eventY: number, deltaX: 
     return
   }
   const webView = WebViewStates.get(id)
-  const normalizedDeltaY = WheelEvent.normalizeDelta(deltaY, IsFirefox.isFirefox)
+  const { domMatrix, isFirefox, zoomFactor } = webView
+  const normalizedDeltaY = WheelEvent.normalizeDelta(deltaY, isFirefox)
   const relativeX = eventX
   const relativeY = eventY
-  const { domMatrix, zoomFactor } = webView
   const currentZoomFactor = GetCurrentZoomFactor.getCurrentZoomFactor(zoomFactor, normalizedDeltaY)
   const newDomMatrix = DomMatrix.zoomInto(domMatrix, currentZoomFactor, relativeX, relativeY)
   const newWebView: WebView = {

--- a/packages/extension/src/parts/IsFirefox/IsFirefox.ts
+++ b/packages/extension/src/parts/IsFirefox/IsFirefox.ts
@@ -1,4 +1,4 @@
-const getIsFirefox = (): boolean => {
+export const getIsFirefox = (): boolean => {
   if (typeof navigator === 'undefined') {
     return false
   }
@@ -13,5 +13,3 @@ const getIsFirefox = (): boolean => {
   }
   return navigator.userAgent.toLowerCase().includes('firefox')
 }
-
-export const isFirefox: boolean = getIsFirefox()

--- a/packages/extension/src/parts/WebView/WebView.ts
+++ b/packages/extension/src/parts/WebView/WebView.ts
@@ -1,6 +1,7 @@
 export interface WebView {
   readonly domMatrix: Readonly<DOMMatrixReadOnly>
   readonly error: boolean
+  readonly isFirefox: boolean
   readonly maxZoom: number
   readonly minZoom: number
   readonly pointerDown: boolean

--- a/packages/extension/test/HandleWheel.test.ts
+++ b/packages/extension/test/HandleWheel.test.ts
@@ -33,9 +33,10 @@ beforeAll(() => {
   }
 })
 
-const createState = (): WebView => ({
+const createState = (isFirefox = false): WebView => ({
   domMatrix: { a: 1, b: 0, c: 0, d: 1, e: 0, f: 0 } as DOMMatrixReadOnly,
   error: false,
+  isFirefox,
   maxZoom: 2 ** 15,
   minZoom: 0.1,
   pointerDown: false,
@@ -61,4 +62,13 @@ test('zooms into the pointer position for vertical wheel events', () => {
   HandleWheel.handleWheel(id, 10, 20, 0, -1)
 
   expect(WebViewStates.get(id).domMatrix.a).toBeGreaterThan(1)
+})
+
+test('normalizes wheel events using the browser stored in state', () => {
+  const id = 103
+  WebViewStates.set(id, createState(true))
+
+  HandleWheel.handleWheel(id, 10, 20, 0, -114)
+
+  expect(WebViewStates.get(id).domMatrix.a).toBe(1.26)
 })

--- a/packages/extension/test/IsFirefox.test.ts
+++ b/packages/extension/test/IsFirefox.test.ts
@@ -1,4 +1,5 @@
-import { afterEach, expect, jest, test } from '@jest/globals'
+import { afterEach, expect, test } from '@jest/globals'
+import * as IsFirefox from '../src/parts/IsFirefox/IsFirefox.ts'
 
 const originalNavigator = Object.getOwnPropertyDescriptor(globalThis, 'navigator')
 
@@ -9,12 +10,6 @@ const setNavigator = (navigator: unknown): void => {
   })
 }
 
-const loadIsFirefox = async (): Promise<boolean> => {
-  jest.resetModules()
-  const module = await import('../src/parts/IsFirefox/IsFirefox.ts')
-  return module.isFirefox
-}
-
 afterEach(() => {
   if (originalNavigator) {
     Object.defineProperty(globalThis, 'navigator', originalNavigator)
@@ -23,20 +18,20 @@ afterEach(() => {
   }
 })
 
-test('returns false when navigator is unavailable', async () => {
+test('returns false when navigator is unavailable', () => {
   setNavigator(undefined)
 
-  await expect(loadIsFirefox()).resolves.toBe(false)
+  expect(IsFirefox.getIsFirefox()).toBe(false)
 })
 
-test('uses user agent brands when available', async () => {
+test('uses user agent brands when available', () => {
   setNavigator({ userAgentData: { brands: ['Firefox'] } })
 
-  await expect(loadIsFirefox()).resolves.toBe(true)
+  expect(IsFirefox.getIsFirefox()).toBe(true)
 })
 
-test('falls back to the user agent when brands are unavailable', async () => {
+test('falls back to the user agent when brands are unavailable', () => {
   setNavigator({ userAgent: 'Mozilla Firefox', userAgentData: {} })
 
-  await expect(loadIsFirefox()).resolves.toBe(true)
+  expect(IsFirefox.getIsFirefox()).toBe(true)
 })

--- a/packages/extension/test/Reset.test.ts
+++ b/packages/extension/test/Reset.test.ts
@@ -29,6 +29,7 @@ test('resets zoom, drag offset, and pointer state', () => {
   const state: WebView = {
     domMatrix: { a: 2, b: 0, c: 0, d: 2, e: 10, f: 20 } as DOMMatrixReadOnly,
     error: false,
+    isFirefox: false,
     maxZoom: 2 ** 15,
     minZoom: 0.1,
     pointerDown: true,

--- a/packages/extension/test/SetSavedState.test.ts
+++ b/packages/extension/test/SetSavedState.test.ts
@@ -27,6 +27,7 @@ beforeAll(() => {
 const createState = (): WebView => ({
   domMatrix: {} as DOMMatrixReadOnly,
   error: false,
+  isFirefox: false,
   maxZoom: 2 ** 15,
   minZoom: 0.1,
   pointerDown: false,


### PR DESCRIPTION
Compute Firefox detection when media preview state is created and retain it in WebView state. Use the stored value when normalizing wheel events.